### PR TITLE
Recreate automatic dependabot-npm update

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,18 @@
+# This file is managed in the repository Qualifyze/dev-infrastructure
+# New updates of this file on  Qualifyze/dev-infrastructure will automatically trigger new pull requests to up this file here
+# You can still add small amendments here, but if any larger divergence is necessary, then it would be recommended
+# to either disable this push-template in Qualifyze/dev-infrastructure, or if this change is applicable to all repositories,
+# edit it here https://github.com/Qualifyze/dev-infrastructure/blob/main/templates/dependabot-npm.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    reviewers:
+      - 'Qualifyze/dev-people'
+registries:
+  npm-npmjs:
+    type: npm-registry
+    url: https://registry.npmjs.org
+    token: { { secrets.NPM_TOKEN } }


### PR DESCRIPTION
## What
The file committed here is actually managed by the repository
`Qualifyze/dev-infrastructure`. I force-pushed to the `main` branch, which
effectively resulted in a divergence in git histories. This closed the
PRs opened by the `dev-infrastructure` repo, so I need to recreate them
manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/4)
<!-- Reviewable:end -->
