### PR TITLE
Recreate automatic editorconfig update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# This file is managed in the repository Qualifyze/dev-infrastructure
+# New updates of this file on  Qualifyze/dev-infrastructure will automatically trigger new pull requests to up this file here
+# You can still add small amendments here, but if any larger divergence is necessary, then it would be recommended
+# to either disable this push-template in Qualifyze/dev-infrastructure, or if this change is applicable to all repositories,
+# edit it here https://github.com/Qualifyze/dev-infrastructure/blob/main/templates/editor-config.
+[*]
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+indent_size = 2


### PR DESCRIPTION
The file committed here is actually managed by the repository
`Qualifyze/dev-infrastructure`. I force-pushed to the `main` branch, which
effectively resulted in a divergence in git histories. This closed the
PRs opened by the `dev-infrastructure` repo, so I need to recreate them
manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/5)
<!-- Reviewable:end -->
