### PR TITLE
Fix ESLint on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
ESLint was fine on macOS and Linux, but failing on Windows.
Windows handles line endings differently, which can be fixed by
explicityle telling it to use `LF` instead of its default `CRLF`.

More specifically, this difference was interfering with Prettier's\
`endOfLine` option:
https://prettier.io/docs/en/options.html#end-of-line

This fixes #6 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/8)
<!-- Reviewable:end -->
