### PR TITLE
Replace `yarn` calls with `npm`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "clean": "shx rm -rf dist",
     "build:cjs": "rollup -c rollup.config.js",
     "build:esm": "babel --out-dir dist src",
-    "build": "yarn clean && yarn build:cjs && yarn build:esm",
+    "build": "npm run clean && npm run build:cjs && npm run build:esm",
     "start": "start-storybook --port 3333 --quiet",
     "lint:scripts": "eslint '{src,.storybook}/**/*.{jsx,js}'",
     "lint:styles": "stylelint '{src,.storybook}/**/*.{jsx,js}'",
-    "lint": "yarn lint:scripts && yarn lint:styles",
+    "lint": "npm run lint:scripts && npm run lint:styles",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
There were some left-overs from the move to `npm`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/56)
<!-- Reviewable:end -->
