### PR TITLE
Fix enormous `LoadingSpinner` in FireFox & Safari

### DIFF
--- a/src/components/LoadingSpinner/index.jsx
+++ b/src/components/LoadingSpinner/index.jsx
@@ -10,7 +10,6 @@ const Wrapper = styled('div')({
   flex: '1 1 auto',
   alignItems: 'center',
   justifyContent: 'center',
-  scale: '2',
   width: '80px',
   height: '80px',
 })


### PR DESCRIPTION
There was a rogue `scale` css property that's only supported in these
two browsers: https://developer.mozilla.org/en-US/docs/Web/CSS/scale

## Before
![image](https://user-images.githubusercontent.com/6179211/124275984-870d0000-db43-11eb-8a2b-898360c25a05.png)

## After
![image](https://user-images.githubusercontent.com/6179211/124275989-896f5a00-db43-11eb-9240-2377a6320cbe.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/62)
<!-- Reviewable:end -->
