### PR TITLE
Check how dependabot limit for PRs works

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: weekly
     reviewers:
       - 'Qualifyze/dev-people'
+    open-pull-requests-limit: 1


### PR DESCRIPTION
## What

Updated dependabot setting `open-pull-requests-limit` to 1 from the default 5.

It should not affect the security updates.

## Why

We get many PRs which are not related to security updates, so low priority to tackle.

## What's next

Done for this repo only to see the effect. If we like it, then the change can be propagated to all the repos via [dev-infrastructure](https://github.com/Qualifyze/dev-infrastructure). Otherwise, just roll back it here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/84)
<!-- Reviewable:end -->
