### PR TITLE
Fix branch name in GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ v1 ]
+    branches: [ main ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ main ]
 
 jobs:
   test:
@@ -31,7 +31,7 @@ jobs:
       - run: npm run build
 
   deploy:
-    if: github.ref == 'refs/heads/v1'
+    if: github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.log
 
 .DS_Store
+.idea

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build:esm": "babel --out-dir dist src",
     "build": "npm run clean && npm run build:cjs && npm run build:esm",
     "start": "start-storybook --port 3333 --quiet",
-    "lint:scripts": "eslint '{src,.storybook}/**/*.{jsx,js}'",
-    "lint:styles": "stylelint '{src,.storybook}/**/*.{jsx,js}'",
+    "lint:scripts": "eslint {src,.storybook}/**/*.{jsx,js}",
+    "lint:styles": "stylelint {src,.storybook}/**/*.{jsx,js}",
     "lint": "npm run lint:scripts && npm run lint:styles",
     "test": "jest"
   },

--- a/src/components/TextField/index.stories.jsx
+++ b/src/components/TextField/index.stories.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react'
-import { text, number } from '@storybook/addon-knobs'
+import { text } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 import { Formik, Form } from 'formik'
 import * as Yup from 'yup'


### PR DESCRIPTION
## What

Rename `v1` to `main` in the build workflow so it's triggered on PRs to the default branch.

## Why

This unblocks PR merges after the branch protection state is coming from `dev-inftrastructure`.

## Testing

If we can merge this PR after review and build - all is good :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/101)
<!-- Reviewable:end -->
