### PR TITLE
Use custom icon for `SelectField`

### DIFF
--- a/src/components/SelectField/index.jsx
+++ b/src/components/SelectField/index.jsx
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types'
 
 import FieldMessage from '../FieldMessage'
 import FieldLabel from '../FieldLabel'
+import Icon from '../Icon'
+import Flex from '../Flex'
 
 import baseTheme from './baseTheme'
 import Wrapper from './Wrapper'
@@ -57,6 +59,15 @@ const errorVariant = customTheme => ({
   boxShadowDefault: 'inset 0 0 0 2px',
   boxShadowHover: 'inset 0 0 0 2px',
 })
+
+// eslint-disable-next-line react/prop-types
+const DropdownIndicator = ({ innerProps }) => {
+  return (
+    <Flex sx={{ px: 2, color: 'grey.700' }} {...innerProps}>
+      <Icon name="chevrondown" color="currentColor" />
+    </Flex>
+  )
+}
 
 const SelectField = ({
   options,
@@ -128,12 +139,6 @@ const SelectField = ({
         ? baseTheme.optionTextSelected
         : baseTheme.optionTextColor,
     }),
-    dropdownIndicator: (provided, state) => ({
-      ...provided,
-      color:
-        (state.isFocused && state.theme.colors.primary) ||
-        baseTheme.placeholderColor,
-    }),
     indicatorSeparator: () => ({ display: 'none' }),
   }
 
@@ -160,6 +165,7 @@ const SelectField = ({
         }
         isDisabled={disabled}
         menuPlacement={menuPlacement}
+        components={{ DropdownIndicator }}
       />
       {meta.error && meta.touched && (
         <FieldMessage tone="critical" message={meta.error} />


### PR DESCRIPTION
So far, we've been using the default dropdown indicator icon from
`react-select` in our `SelectField` component. It's very easy to use our
own icons, though, so let's do it.

## Before
![image](https://user-images.githubusercontent.com/6179211/127739176-07f354ae-e9cc-4196-b508-b29154d7f8f5.png)

## After
![image](https://user-images.githubusercontent.com/6179211/127739178-5e88114c-9a08-4a33-b5d6-2e64bdbc54d5.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/103)
<!-- Reviewable:end -->
