### PR TITLE
Trigger `onBlur` for `SelectField`

### DIFF
--- a/src/components/SelectField/index.jsx
+++ b/src/components/SelectField/index.jsx
@@ -136,6 +136,7 @@ const SelectField = ({
     }),
     indicatorSeparator: () => ({ display: 'none' }),
   }
+
   return (
     <Wrapper size={size}>
       <FieldLabel htmlFor={name} label={label} />
@@ -146,6 +147,11 @@ const SelectField = ({
         onChange={option => {
           helpers.setValue(option.value)
         }}
+        onBlur={() => {
+          helpers.setTouched(true)
+        }}
+        // `value` needs to be set like this to make sure value gets updated
+        // when the form field is changed, e.g., when resetting the form
         value={options.find(option => option.value === field.value) || ''}
         styles={customStyles}
         theme={


### PR DESCRIPTION
We never synced blur events from `react-select` to Formik, which is
needed for proper validation. So whenever someone blurs out of the
select input, we should tell Formik by using `setTouched`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/111)
<!-- Reviewable:end -->
