### PR TITLE
Add test for matching `emotion` versions

### DIFF
--- a/src/__tests__/__snapshots__/matching-emotion-versions.test.jsx.snap
+++ b/src/__tests__/__snapshots__/matching-emotion-versions.test.jsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ensure matching versions of Emotion 1`] = `
+<div
+  class="css-zxunkz"
+>
+  hola
+</div>
+`;

--- a/src/__tests__/matching-emotion-versions.test.jsx
+++ b/src/__tests__/matching-emotion-versions.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { render, screen } from '../util/test'
+import { styled, shouldForwardProp } from '../util/style'
+
+const RandomStyledComponent = styled('div', { shouldForwardProp })(props => {
+  // console.log('props', props)
+  return {
+    color: props.theme.colors.primary[700],
+  }
+})
+
+/**
+ * We need to ensure we install matching versions of Emotion (`@emotion/styled`
+ * and `@emotion/core`) because if we don't we'd break our styling entirely.
+ *
+ * One symptom of that is: ThemeProvider provides the `theme` via context but
+ * the `theme` prop that the exported `styled` function access is undefined.
+ *
+ * You can easily validate that by having a component like
+ * `RandomStyledComponent` and making sure that `props.theme` matches what we
+ * export from `util/style/theme`
+ */
+test('Ensure matching versions of Emotion', () => {
+  render(<RandomStyledComponent>hola</RandomStyledComponent>)
+  const Component = screen.getByText(/hola/)
+  expect(Component).toMatchSnapshot()
+  expect(Component).toHaveStyle({ color: 'hsl(223, 60%, 29%)' }) // Our primary.700 color
+})


### PR DESCRIPTION
We need to ensure we install matching versions of Emotion
(`@emotion/styled` and `@emotion/core`) because if we don't we'd break
our styling entirely. This is because different versions of Emotion
operate on distinct contexts, and, thus, the `styled` function we export
from the design system doesn't have access to the exported  `theme`.

This adds a test that should(tm) be red every time we accidentally have
mismatched Emotion versions. It's basically testing if a component
created with `styled()` has access to the `theme`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/113)
<!-- Reviewable:end -->
