### PR TITLE
Add missing `message` to `SelectField`

### DIFF
--- a/.changeset/mean-worms-rush.md
+++ b/.changeset/mean-worms-rush.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Add missing `message` prop to `SelectField`

--- a/src/components/Form/index.stories.jsx
+++ b/src/components/Form/index.stories.jsx
@@ -109,6 +109,7 @@ export const Default = () => {
                   <SelectField
                     name="country"
                     label="Country of residence"
+                    message="A country with nice beaches is preferable, of course"
                     placeholder="Country"
                     options={[
                       { label: 'Germany', value: 'DE' },

--- a/src/components/SelectField/index.jsx
+++ b/src/components/SelectField/index.jsx
@@ -24,8 +24,14 @@ const SelectField = ({
   size,
   menuPlacement,
   noOptionsMessage,
+  message,
+  reserveMessageSpace,
 }) => {
   const [field, meta, helpers] = useField({ name })
+  const hasError = meta.error && meta.touched
+  const messageToShow = hasError
+    ? `${meta.error.charAt(0).toUpperCase()}${meta.error.slice(1)}`
+    : message ?? null
 
   return (
     <Wrapper size={size}>
@@ -53,9 +59,12 @@ const SelectField = ({
         noOptionsMessage={noOptionsMessage}
         components={{ DropdownIndicator }}
       />
-      {meta.error && meta.touched && (
-        <FieldMessage tone="critical" message={meta.error} />
-      )}
+      {reserveMessageSpace || messageToShow ? (
+        <FieldMessage
+          message={messageToShow}
+          tone={hasError ? 'critical' : 'neutral'}
+        />
+      ) : null}
     </Wrapper>
   )
 }
@@ -71,6 +80,8 @@ SelectField.propTypes = {
   size: PropTypes.oneOf(['tiny', 'small', 'standard', 'large']),
   menuPlacement: PropTypes.oneOf(['auto', 'top', 'bottom']),
   noOptionsMessage: PropTypes.func,
+  message: PropTypes.string,
+  reserveMessageSpace: PropTypes.bool,
 }
 
 SelectField.defaultProps = {
@@ -79,5 +90,7 @@ SelectField.defaultProps = {
   size: 'standard',
   label: '',
   menuPlacement: 'auto',
+  reserveMessageSpace: true,
+  message: undefined,
 }
 export default SelectField

--- a/src/components/SelectField/index.stories.jsx
+++ b/src/components/SelectField/index.stories.jsx
@@ -35,10 +35,16 @@ const options = [
     label: 'El Secreto de sus Ojos',
     value: 'elSecretoDeSusOjos',
   },
+  {
+    label: 'Frozen',
+    value: 'frozen',
+  },
 ]
 
 const selectSchema = Yup.object().shape({
-  movie: Yup.string().required(),
+  movie: Yup.string()
+    .matches(/frozen/, 'Ooops, think again!')
+    .required(),
 })
 
 export const Default = () => {
@@ -47,6 +53,7 @@ export const Default = () => {
   const placeholder = text('Placeholder', 'Select a movie')
   const availableSizes = ['tiny', 'small', 'standard', 'large']
   const size = select('Size', availableSizes, 'standard')
+  const message = text('Message', 'E.g., Frozen')
   const noOptionsMessage = text(
     'No options message',
     'Oh come on, dont be so picky'
@@ -74,6 +81,7 @@ export const Default = () => {
                   placeholder={placeholder}
                   disabled={disabled}
                   size={size}
+                  message={message}
                   noOptionsMessage={() => noOptionsMessage}
                 />
               </Box>


### PR DESCRIPTION
We somehow missed this until now, but we should have a `message` prop
for all form fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/145)
<!-- Reviewable:end -->
