### PR TITLE
Set text color for select and text fields explicitly

### DIFF
--- a/.changeset/gorgeous-elephants-kiss.md
+++ b/.changeset/gorgeous-elephants-kiss.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Set text color for select and text fields explicitly

--- a/src/components/AutosuggestField/index.jsx
+++ b/src/components/AutosuggestField/index.jsx
@@ -36,6 +36,7 @@ const Input = styled('input')(
     'appearance': 'none',
     'background': props.theme.colors.white,
     'outline': 'none',
+    'color': props.theme.colors.grey[900],
     '&:hover': {
       boxShadow: `inset 0 0 0 1px ${props.theme.colors.grey[800]}`,
     },

--- a/src/components/SelectField/baseTheme.js
+++ b/src/components/SelectField/baseTheme.js
@@ -22,6 +22,7 @@ export const baseTheme = {
   hoverOverOption: theme.colors.primary[100],
   valueContainerTextColor: 'black',
   backGroundControl: 'white',
+  inputColor: theme.colors.grey[900],
   optionTextColor: theme.colors.grey[900],
   optionTextSelected: theme.colors.white,
   placeholderColor: theme.colors.grey[700],
@@ -80,6 +81,7 @@ export const customStyles = {
   valueContainer: provided => ({ ...provided }),
   input: () => ({
     margin: 0,
+    color: baseTheme.inputColor,
   }),
   menu: provided => ({
     ...provided,

--- a/src/components/TextArea/index.jsx
+++ b/src/components/TextArea/index.jsx
@@ -34,6 +34,7 @@ const PlainArea = styled('textarea')(
     'appearance': 'none',
     'background': props.theme.colors.white,
     'outline': 'none',
+    'color': props.theme.colors.grey[900],
     'resize': props.resize,
     '&:hover': {
       boxShadow: `0 0 0 1px ${props.theme.colors.grey[800]}`,

--- a/src/components/TextField/index.jsx
+++ b/src/components/TextField/index.jsx
@@ -33,6 +33,7 @@ const Input = styled('input')(
     'appearance': 'none',
     'background': props.theme.colors.white,
     'outline': 'none',
+    'color': props.theme.colors.grey[900],
     '&:hover': {
       boxShadow: `inset 0 0 0 1px ${props.theme.colors.grey[800]}`,
     },


### PR DESCRIPTION
## What

Set text color for select and text fields explicitly. This was noticed when using select creatable with a container setting color to white due to dark background. Select creatable uses inline style for input with `color: inherit` which was taking that container color as we didn't provide the style for the select itself.

## Why

Design system generally does not rely on the default browser styles. The color for input fields was still coming from there which is fixed here.

## Testing

Use storybook preview link.

## Who is affected

Consumers who changed select or input colors bypassing Design System.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/147)
<!-- Reviewable:end -->
