### PR TITLE
Allow customization of new option object, option label in menu and solve creation option blink

### DIFF
--- a/.changeset/stale-hats-worry.md
+++ b/.changeset/stale-hats-worry.md
@@ -1,0 +1,6 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Allow customization of new option object, option label in menu and solve issue
+with blinking creation option.

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,5 @@ module.exports = api => ({
     ],
     '@babel/preset-react',
   ],
-  ignore: api.env('test')
-    ? []
-    : ['**/*.stories.jsx', '**/*.test.jsx', 'src/util/test'],
+  ignore: api.env('test') ? [] : ['**/*.test.jsx', 'src/util/test'],
 })

--- a/src/components/MultiSelectAsyncCreatableField/index.stories.jsx
+++ b/src/components/MultiSelectAsyncCreatableField/index.stories.jsx
@@ -26,14 +26,17 @@ const multiSelectSchema = Yup.object().shape({
 const options = [
   {
     label: 'Doxylamine succinate',
+    hint: 'no idea',
     value: 'doxy',
   },
   {
     label: 'Ascorbic acid',
+    hint: 'just a hint',
     value: 'acid',
   },
   {
     label: 'Something dangerous',
+    hint: 'and strong',
     value: 'etwa',
   },
   {
@@ -97,6 +100,13 @@ export const Default = () => {
                   disabled={disabled}
                   size={size}
                   createNewLabelText={createNewLabelText}
+                  createOption={value => ({
+                    value: `new:${value}`,
+                    label: value,
+                  })}
+                  formatOptionLabel={({ label, hint }) =>
+                    hint ? `${label} (${hint})` : label
+                  }
                   loadingMessage={loadingMessage}
                   noOptionsMessage={noOptionsMessage}
                   message={message}


### PR DESCRIPTION
## What

Minor improvements for async multi select with a creation option:
- allow customization of new option object so it's possible to assign it some id as value
- allow formatting of option label in the drop-down menu
- allow creation of new option while the list is still loading which unblocks the user and solves the blink when the options are loaded

## Why

These would be very useful for the products multi-select (QC-1121).

See #102 where multi-select has been introduced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/148)
<!-- Reviewable:end -->
