### PR TITLE
Fix ES module generation

### DIFF
--- a/.changeset/popular-fireants-repair.md
+++ b/.changeset/popular-fireants-repair.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Fix ES module generation, exclude tests and stories from the library artifacts.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,16 @@
-module.exports = {
+module.exports = api => ({
   presets: [
     [
       '@babel/preset-env',
       {
+        modules: api.env('test') ? 'cjs' : false,
         useBuiltIns: 'usage',
         corejs: 3,
       },
     ],
     '@babel/preset-react',
   ],
-}
+  ignore: api.env('test')
+    ? []
+    : ['**/*.stories.jsx', '**/*.test.jsx', 'src/util/test'],
+})


### PR DESCRIPTION
## What

Keep ES6 module style (`import` instead of `require`) and exclude tests and stories from the library ESM output.

## Why

Enables tree-shaking and IDE auto-suggestions.

## How

Added `module` config for `babel-preset-env` and `ignore` in babel config.

## Testing

Run `npm run build` and:
- check the content of `dist/index.js` - `import` is not replaced with `require`.
- check that no files `dist/**/*.stories.js` or `dist/**/*.test.js`.

## Who is affected

Hopefully nobody as `dist/index.js` is referenced as ES6 module (`module` in `package.json`) and tests/stories should not have been referenced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/149)
<!-- Reviewable:end -->
