### PR TITLE
Support array validators for multi-select field value

### DIFF
--- a/.changeset/four-poets-breathe.md
+++ b/.changeset/four-poets-breathe.md
@@ -2,4 +2,4 @@
 '@qualifyze/design-system': patch
 ---
 
-Support single error messages and undefined field value in multi-selects.
+Support array validators for multi-select field value.

--- a/.changeset/four-poets-breathe.md
+++ b/.changeset/four-poets-breathe.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Support single error messages and undefined field value in multi-selects.

--- a/src/components/MultiSelectAsyncCreatableField/index.jsx
+++ b/src/components/MultiSelectAsyncCreatableField/index.jsx
@@ -67,7 +67,7 @@ const MultiSelectAsyncCreatableField = ({
           // We only need a string array in Formik state...
           helpers.setValue(valueArray ? valueArray.map(o => o.value) : [])
           // ...but we need to cache the object array locally
-          setCachedOptions(valueArray || [])
+          setCachedOptions(valueArray)
         }}
         onCreateOption={valueString => {
           // allow customization of new option object so that the consumer
@@ -80,7 +80,7 @@ const MultiSelectAsyncCreatableField = ({
                 label: valueString,
               }
           // Add newly created value...
-          helpers.setValue([...(field.value || []), option.value])
+          helpers.setValue([...field.value, option.value])
           // ...and save the object locally
           setCachedOptions(current => [...current, option])
           onCreateOption?.()
@@ -111,13 +111,13 @@ const MultiSelectAsyncCreatableField = ({
           // this is needed as if you go through all options and return the matches
           // the order will match the order of options and not selected options
           // from the user
-          field.value?.map(
+          field.value.map(
             valueItem =>
               cachedOptions.find(({ value }) => value === valueItem) || {
                 value: valueItem,
                 label: valueItem,
               }
-          ) || []
+          )
         }
         styles={customStyles}
         theme={

--- a/src/components/MultiSelectAsyncCreatableField/index.jsx
+++ b/src/components/MultiSelectAsyncCreatableField/index.jsx
@@ -39,11 +39,14 @@ const MultiSelectAsyncCreatableField = ({
 }) => {
   const [field, meta, helpers] = useField({ name })
   const hasError = meta.error && meta.touched
+  let messageToShow = message ?? null
 
-  const errorText = hasError ? meta.error.filter(err => err !== '')[0] : ''
-  const messageToShow = hasError
-    ? `${errorText.charAt(0).toUpperCase()}${errorText.slice(1)}`
-    : message ?? null
+  if (hasError) {
+    const errorText = Array.isArray(meta.error)
+      ? meta.error.find(err => err)
+      : meta.error
+    messageToShow = `${errorText.charAt(0).toUpperCase()}${errorText.slice(1)}`
+  }
 
   // Options are not available locally, so we need to cache all options locally
   const [cachedOptions, setCachedOptions] = React.useState(defaultOptions)
@@ -64,7 +67,7 @@ const MultiSelectAsyncCreatableField = ({
           // We only need a string array in Formik state...
           helpers.setValue(valueArray ? valueArray.map(o => o.value) : [])
           // ...but we need to cache the object array locally
-          setCachedOptions(valueArray)
+          setCachedOptions(valueArray || [])
         }}
         onCreateOption={valueString => {
           // allow customization of new option object so that the consumer
@@ -77,7 +80,7 @@ const MultiSelectAsyncCreatableField = ({
                 label: valueString,
               }
           // Add newly created value...
-          helpers.setValue([...field.value, option.value])
+          helpers.setValue([...(field.value || []), option.value])
           // ...and save the object locally
           setCachedOptions(current => [...current, option])
           onCreateOption?.()
@@ -108,18 +111,17 @@ const MultiSelectAsyncCreatableField = ({
           // this is needed as if you go through all options and return the matches
           // the order will match the order of options and not selected options
           // from the user
-          field.value.map(
+          field.value?.map(
             valueItem =>
               cachedOptions.find(({ value }) => value === valueItem) || {
                 value: valueItem,
                 label: valueItem,
               }
-          )
+          ) || []
         }
         styles={customStyles}
         theme={
-          (meta.error && meta.touched && errorVariant(baseTheme)) ||
-          defaultVariant(baseTheme)
+          (hasError && errorVariant(baseTheme)) || defaultVariant(baseTheme)
         }
         isDisabled={disabled}
         menuPlacement={menuPlacement}

--- a/src/components/MultiSelectAsyncCreatableField/index.stories.jsx
+++ b/src/components/MultiSelectAsyncCreatableField/index.stories.jsx
@@ -79,9 +79,7 @@ export const Default = () => {
 
   return (
     <Formik
-      initialValues={{
-        products: [],
-      }}
+      initialValues={{}}
       onSubmit={values => {
         action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
       }}

--- a/src/components/MultiSelectAsyncCreatableField/index.stories.jsx
+++ b/src/components/MultiSelectAsyncCreatableField/index.stories.jsx
@@ -79,7 +79,9 @@ export const Default = () => {
 
   return (
     <Formik
-      initialValues={{}}
+      initialValues={{
+        products: [],
+      }}
       onSubmit={values => {
         action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
       }}

--- a/src/components/MultiSelectCreatableField/index.jsx
+++ b/src/components/MultiSelectCreatableField/index.jsx
@@ -60,7 +60,7 @@ const MultiSelectCreatableField = ({
         }
         onCreateOption={newValue => {
           // take the current selection, plus anything new that might be added
-          helpers.setValue([...(field.value || []), newValue])
+          helpers.setValue([...field.value, newValue])
           onCreateOption?.()
         }}
         formatCreateLabel={input => {
@@ -82,13 +82,13 @@ const MultiSelectCreatableField = ({
           // this is needed as if you go through all options and return the matches
           // the order will match the order of options and not selected options
           // from the user
-          field.value?.map(
+          field.value.map(
             valueItem =>
               options.find(({ value }) => value === valueItem) || {
                 value: valueItem,
                 label: valueItem,
               }
-          ) || []
+          )
         }
         styles={customStyles}
         theme={

--- a/src/components/MultiSelectCreatableField/index.jsx
+++ b/src/components/MultiSelectCreatableField/index.jsx
@@ -34,10 +34,14 @@ const MultiSelectCreatableField = ({
 }) => {
   const [field, meta, helpers] = useField({ name })
   const hasError = meta.error && meta.touched
-  const errorText = hasError ? meta.error.filter(err => err !== '')[0] : ''
-  const messageToShow = hasError
-    ? `${errorText.charAt(0).toUpperCase()}${errorText.slice(1)}`
-    : message ?? null
+  let messageToShow = message ?? null
+
+  if (hasError) {
+    const errorText = Array.isArray(meta.error)
+      ? meta.error.find(err => err)
+      : meta.error
+    messageToShow = `${errorText.charAt(0).toUpperCase()}${errorText.slice(1)}`
+  }
 
   return (
     <Wrapper size={size}>
@@ -51,12 +55,12 @@ const MultiSelectCreatableField = ({
         options={options}
         placeholder={placeholder}
         name={field.name}
-        onChange={option =>
-          helpers.setValue(option ? option.map(o => o.value) : [])
+        onChange={newOptions =>
+          helpers.setValue(newOptions ? newOptions.map(o => o.value) : [])
         }
         onCreateOption={newValue => {
           // take the current selection, plus anything new that might be added
-          helpers.setValue([...field.value, newValue])
+          helpers.setValue([...(field.value || []), newValue])
           onCreateOption?.()
         }}
         formatCreateLabel={input => {
@@ -78,20 +82,17 @@ const MultiSelectCreatableField = ({
           // this is needed as if you go through all options and return the matches
           // the order will match the order of options and not selected options
           // from the user
-          field.value
-            ? field.value.map(
-                valueItem =>
-                  options.filter(option => option.value === valueItem)[0] || {
-                    value: valueItem,
-                    label: valueItem,
-                  }
-              )
-            : []
+          field.value?.map(
+            valueItem =>
+              options.find(({ value }) => value === valueItem) || {
+                value: valueItem,
+                label: valueItem,
+              }
+          ) || []
         }
         styles={customStyles}
         theme={
-          (meta.error && meta.touched && errorVariant(baseTheme)) ||
-          defaultVariant(baseTheme)
+          (hasError && errorVariant(baseTheme)) || defaultVariant(baseTheme)
         }
         isDisabled={disabled}
         menuPlacement={menuPlacement}

--- a/src/components/MultiSelectCreatableField/index.stories.jsx
+++ b/src/components/MultiSelectCreatableField/index.stories.jsx
@@ -60,9 +60,7 @@ export const Default = () => {
 
   return (
     <Formik
-      initialValues={{
-        products: '',
-      }}
+      initialValues={{}}
       onSubmit={values => {
         action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
       }}

--- a/src/components/MultiSelectCreatableField/index.stories.jsx
+++ b/src/components/MultiSelectCreatableField/index.stories.jsx
@@ -60,7 +60,9 @@ export const Default = () => {
 
   return (
     <Formik
-      initialValues={{}}
+      initialValues={{
+        products: [],
+      }}
       onSubmit={values => {
         action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
       }}

--- a/src/components/MultiSelectField/index.jsx
+++ b/src/components/MultiSelectField/index.jsx
@@ -89,8 +89,8 @@ const MultiSelectField = ({
         options={options}
         placeholder={placeholder}
         name={field.name}
-        onChange={option =>
-          helpers.setValue(option ? option.map(o => o.value) : [])
+        onChange={newOptions =>
+          helpers.setValue(newOptions ? newOptions.map(o => o.value) : [])
         }
         onBlur={() => {
           helpers.setTouched(true)
@@ -103,13 +103,13 @@ const MultiSelectField = ({
           // this is needed as if you go through all options and return the matches
           // the order will match the order of options and not selected options
           // from the user
-          field.value?.map(
+          field.value.map(
             valueItem =>
               options.find(({ value }) => value === valueItem) || {
                 value: valueItem,
                 label: valueItem,
               }
-          ) || []
+          )
         }
         styles={customStyles}
         theme={

--- a/src/components/MultiSelectField/index.jsx
+++ b/src/components/MultiSelectField/index.jsx
@@ -68,11 +68,14 @@ const MultiSelectField = ({
 }) => {
   const [field, meta, helpers] = useField({ name })
   const hasError = meta.error && meta.touched
+  let messageToShow = message ?? null
 
-  const errorText = hasError ? meta.error.filter(err => err !== '')[0] : ''
-  const messageToShow = hasError
-    ? `${errorText.charAt(0).toUpperCase()}${errorText.slice(1)}`
-    : message ?? null
+  if (hasError) {
+    const errorText = Array.isArray(meta.error)
+      ? meta.error.find(err => err)
+      : meta.error
+    messageToShow = `${errorText.charAt(0).toUpperCase()}${errorText.slice(1)}`
+  }
 
   return (
     <Wrapper size={size}>
@@ -100,17 +103,17 @@ const MultiSelectField = ({
           // this is needed as if you go through all options and return the matches
           // the order will match the order of options and not selected options
           // from the user
-          field.value
-            ? field.value.map(
-                fieldValue =>
-                  options.filter(option => option.value === fieldValue)[0]
-              )
-            : []
+          field.value?.map(
+            valueItem =>
+              options.find(({ value }) => value === valueItem) || {
+                value: valueItem,
+                label: valueItem,
+              }
+          ) || []
         }
         styles={customStyles}
         theme={
-          (meta.error && meta.touched && errorVariant(baseTheme)) ||
-          defaultVariant(baseTheme)
+          (hasError && errorVariant(baseTheme)) || defaultVariant(baseTheme)
         }
         isDisabled={disabled}
         menuPlacement={menuPlacement}

--- a/src/components/MultiSelectField/index.stories.jsx
+++ b/src/components/MultiSelectField/index.stories.jsx
@@ -59,7 +59,9 @@ export const Default = () => {
 
   return (
     <Formik
-      initialValues={{}}
+      initialValues={{
+        products: [],
+      }}
       onSubmit={values => {
         action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
       }}

--- a/src/components/MultiSelectField/index.stories.jsx
+++ b/src/components/MultiSelectField/index.stories.jsx
@@ -57,9 +57,7 @@ export const Default = () => {
 
   return (
     <Formik
-      initialValues={{
-        products: '',
-      }}
+      initialValues={{}}
       onSubmit={values => {
         action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
       }}

--- a/src/components/MultiSelectField/index.stories.jsx
+++ b/src/components/MultiSelectField/index.stories.jsx
@@ -17,7 +17,9 @@ export default { title: 'MultiSelectField', component: MultiSelectField }
 const multiSelectSchema = Yup.object().shape({
   products: Yup.array(
     Yup.string().matches(/^((?!all-the-acid).)*$/, 'Ooops, think again!')
-  ).required(),
+  )
+    .required()
+    .min(3, 'Please select at least 3 products'),
 })
 
 export const Default = () => {

--- a/src/components/SelectCreatableField/index.jsx
+++ b/src/components/SelectCreatableField/index.jsx
@@ -86,8 +86,7 @@ const SelectCreatableField = ({
         })()}
         styles={customStyles}
         theme={
-          (meta.error && meta.touched && errorVariant(baseTheme)) ||
-          defaultVariant(baseTheme)
+          (hasError && errorVariant(baseTheme)) || defaultVariant(baseTheme)
         }
         isDisabled={disabled}
         menuPlacement={menuPlacement}

--- a/src/components/SelectField/index.jsx
+++ b/src/components/SelectField/index.jsx
@@ -58,8 +58,7 @@ const SelectField = ({
         value={options.find(option => option.value === field.value) || ''}
         styles={customStyles}
         theme={
-          (meta.error && meta.touched && errorVariant(baseTheme)) ||
-          defaultVariant(baseTheme)
+          (hasError && errorVariant(baseTheme)) || defaultVariant(baseTheme)
         }
         isDisabled={disabled}
         menuPlacement={menuPlacement}

--- a/src/components/SelectField/index.stories.jsx
+++ b/src/components/SelectField/index.stories.jsx
@@ -43,7 +43,7 @@ const options = [
 
 const selectSchema = Yup.object().shape({
   movie: Yup.string()
-    .matches(/frozen/, 'Ooops, think again!')
+    .matches(/^((?!frozen).)*$/, 'Ooops, think again!')
     .required(),
 })
 

--- a/src/components/TextArea/index.stories.jsx
+++ b/src/components/TextArea/index.stories.jsx
@@ -28,7 +28,7 @@ export const Default = () => {
         action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
       }}
       validationSchema={Yup.object().shape({
-        ssn: Yup.string()
+        tweet: Yup.string()
           .required()
           .max(144, 'That is way too long for a tweet, boomer...'),
       })}


### PR DESCRIPTION
## What

Support error messages from the validator for the whole array value of multi-select, for example `required` and `min` in the following form validation schema:
```
Yup.object().shape({
  products: Yup.array(
    Yup.string().matches(/^((?!all-the-acid).)*$/, 'Ooops, think again!')
  ).required().min(1, 'Please select at least one product'),
})
```

## Why

Otherwise validation errors lead to the exception or it's not possible to use `required()` or `min()` validation on the array for a multi-select.

## Who is affected

Consumers of multi-selects who already use non-array initial values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/160)
<!-- Reviewable:end -->
