### PR TITLE
Disable flex shrink for all the icons

### DIFF
--- a/.changeset/silly-mangos-care.md
+++ b/.changeset/silly-mangos-care.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Disable flex shrink for all the icons.

--- a/src/components/Icon/index.jsx
+++ b/src/components/Icon/index.jsx
@@ -13,6 +13,7 @@ import basicIcons from './basicIcons'
 
 const SVG = styled('svg')(
   {
+    flex: 'none',
     verticalAlign: 'baseline',
     bottom: '-1px',
   },


### PR DESCRIPTION
## What

Disable flex shrink for all the icons.

## Why

The icons should occupy the space corresponding to its size, even being part of flexbox.

## Who is affected

Application users in a positive way: the icon is not resized anymore in case of the insufficient space in flex container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/171)
<!-- Reviewable:end -->
