### PR TITLE
Restore icon tone property

### DIFF
--- a/.changeset/little-turtles-agree.md
+++ b/.changeset/little-turtles-agree.md
@@ -1,0 +1,6 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Restore `Icon` tone so it's used when the color is not provided.
+The `color` prop is kept for backward compatibility, please use `tone` instead.

--- a/src/components/Icon/index.jsx
+++ b/src/components/Icon/index.jsx
@@ -68,6 +68,9 @@ const SVG = styled('svg')(
       info: {
         color: 'secondary.600',
       },
+      current: {
+        color: 'currentColor',
+      },
     },
   }),
   space,
@@ -78,12 +81,7 @@ const SVG = styled('svg')(
 const Icon = ({ name: rawName, size, color, ...props }) => {
   const name = rawName.toLowerCase()
   return (
-    <SVG
-      {...props}
-      viewBox="0 0 92 92"
-      color={color ?? `currentcolor`}
-      size={size}
-    >
+    <SVG {...props} viewBox="0 0 92 92" color={color} size={size}>
       {basicIcons[name] && <path d={basicIcons[name]} fill="currentColor" />}
     </SVG>
   )
@@ -92,9 +90,9 @@ const Icon = ({ name: rawName, size, color, ...props }) => {
 Icon.propTypes = {
   name: PropTypes.string.isRequired,
   size: PropTypes.oneOf(['tiny', 'small', 'standard', 'large', 'gigantic']),
-  // We disabled the next rule on color, beacuse we don't want to give it any default value because it
-  // will overwrite any tone given by the user
-  // eslint-disable-next-line react/require-default-props
+  /**
+   * @deprecated Please use the `tone` prop or set `tone="current"` and set the color on a containing element.
+   */
   color: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
@@ -106,12 +104,14 @@ Icon.propTypes = {
     'secondary',
     'info',
     'caution',
+    'current',
   ]),
 }
 
 Icon.defaultProps = {
   size: 'standard',
-  tone: 'neutral',
+  color: undefined,
+  tone: 'current',
 }
 Icon.displayName = 'Icon'
 

--- a/src/components/Icon/index.stories.jsx
+++ b/src/components/Icon/index.stories.jsx
@@ -101,8 +101,16 @@ export const ColoredIcons = () => {
   const iconName = text('Icon name', 'trophy')
   const iconTone = select(
     'Example A: Icon tone',
-    ['neutral', 'positive', 'critical', 'secondary', 'info', 'caution'],
-    'neutral'
+    [
+      'neutral',
+      'positive',
+      'critical',
+      'secondary',
+      'info',
+      'caution',
+      'current',
+    ],
+    'current'
   )
   const iconColor = text('Example B: Icon color', 'yellow.500')
 


### PR DESCRIPTION
## What

Restore icon `tone` property so it overrides the provided color.

## Why

It's currently ignored. There is an interesting comment on `color` property:

```
We disabled the next rule on color, because we don't want to give it any default value
because it will overwrite any tone given by the user
```

However, currently `tone` is always overridden by the `color` property as the latter is defaulted to `currentColor`.
The problem is that implementing it as stated by the comment would be a breaking change.

Alternative: remove tone property completely.

## Who is affected

Library consumers who provided both `tone` and `color` and ignored the fact that `tone` is completely ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/172)
<!-- Reviewable:end -->
