### PR TITLE
Fix TextLinkButton to work when is nested inside an Actions Component

### DIFF
--- a/.changeset/four-tips-type.md
+++ b/.changeset/four-tips-type.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Make TextLinkButton loading state to work properly when nested inside of an Actions component

--- a/src/components/TextLinkButton/index.jsx
+++ b/src/components/TextLinkButton/index.jsx
@@ -1,12 +1,16 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 
 import { styled } from '../../util/style'
 import TextLink from '../TextLink'
 import Box from '../Box'
+import ActionsContext from '../Actions/ActionsContext'
 
 const Loader = styled.span`
-  display: 'inline-block';
+  display: inline-flex;
+  font-size: inherit;
+  align-self: center;
+  padding-top: 10px;
 
   & > span {
     width: 0.15em;
@@ -42,12 +46,23 @@ const Loader = styled.span`
 `
 
 const TextLinkButton = props => {
+  const actionsContext = useContext(ActionsContext)
+  const isNestedInActions = actionsContext != null
+
   const { isLoading } = props
   return (
-    <Box as="span">
-      <TextLink as="span" role="button" tabIndex={0} {...props} />
+    <Box as="span" sx={{ display: isNestedInActions ? 'flex' : null }}>
+      <TextLink
+        as="span"
+        role="button"
+        tabIndex={0}
+        {...props}
+        style={{
+          fontSize: !!isNestedInActions ? 'inherit' : null,
+        }}
+      />
       {isLoading ? (
-        <Loader aria-hidden>
+        <Loader isNestedInActions={isNestedInActions} aria-hidden>
           <span />
           <span />
           <span />

--- a/src/components/TextLinkButton/index.stories.jsx
+++ b/src/components/TextLinkButton/index.stories.jsx
@@ -6,13 +6,14 @@ import Text from '../Text'
 import Stack from '../Stack'
 import TextLink from '../TextLink'
 import Icon from '../Icon'
+import Actions from '../Actions'
+import Button from '../Button'
 
 import TextLinkButton from './index'
 
 export default { title: 'TextLinkButton', component: TextLinkButton }
 
 export const Default = () => {
-  const [loading, setLoading] = useState(false)
   const hitArea = select('Hit Area', ['standard', 'large'], 'standard')
   const size = select(
     'Text Size',
@@ -24,17 +25,7 @@ export const Default = () => {
     <Stack space={4}>
       <Text size={size}>
         If you want to show a link that triggers some kind of action,{' '}
-        <TextLinkButton
-          onClick={() => {
-            setLoading(true)
-            setTimeout(function () {
-              setLoading(false)
-              alert('Hello there!')
-            }, 2000)
-          }}
-          hitArea={hitArea}
-          isLoading={loading}
-        >
+        <TextLinkButton hitArea={hitArea}>
           you should use a TextLinkButton instead of a TextLink for semantic
           reasons.
         </TextLinkButton>{' '}
@@ -54,4 +45,37 @@ export const Default = () => {
 }
 Default.story = {
   name: 'default',
+}
+
+export const WithActions = () => {
+  const [loading, setLoading] = useState(true)
+  const hitArea = select('Hit Area', ['standard', 'large'], 'standard')
+  const size = select(
+    'Text Size',
+    ['tiny', 'small', 'standard', 'large'],
+    'standard'
+  )
+  return (
+    <Actions>
+      <Button size={size}>I want option 1</Button>
+      <Text size={size}>
+        <TextLinkButton
+          onClick={() => {
+            setLoading(true)
+            setTimeout(function () {
+              setLoading(false)
+              alert('Hello there!')
+            }, 2000)
+          }}
+          hitArea={hitArea}
+          isLoading={loading}
+        >
+          I want to opt out
+        </TextLinkButton>{' '}
+      </Text>
+    </Actions>
+  )
+}
+WithActions.story = {
+  name: 'with Actions',
 }


### PR DESCRIPTION
The component had weird layout issues when nested inside of an Actions components due to the TextLink component being aware of it also and changing its css properties.
TextLinkButton also considers if it is nested in an Actions component and changes its layout accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/177)
<!-- Reviewable:end -->
