### PR TITLE
Re-implement loading indicator for `TextLinkButton`

### DIFF
--- a/.changeset/silver-eggs-share.md
+++ b/.changeset/silver-eggs-share.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Fix issues with TextLinkButton introduced in v1.2.9 (PR #176) and v1.2.8 (PR #177).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualifyze/design-system",
-  "version": "1.2.8",
+  "version": "1.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Actions/index.stories.jsx
+++ b/src/components/Actions/index.stories.jsx
@@ -7,6 +7,10 @@ import TextLinkButton from '../TextLinkButton'
 
 import Actions from './index'
 
+function simulateNetworkRequest() {
+  return new Promise(resolve => setTimeout(resolve, 3000))
+}
+
 export default { title: 'Actions', component: Actions }
 
 export const WithButtons = () => {
@@ -37,7 +41,7 @@ export const WithTextLinkButton = () => {
   return (
     <Actions>
       <Button>Submit</Button>
-      <TextLinkButton onClick="#">Cancel</TextLinkButton>
+      <TextLinkButton>Cancel</TextLinkButton>
     </Actions>
   )
 }
@@ -56,4 +60,56 @@ export const WithButtonsAndLink = () => {
 }
 WithButtonsAndLink.story = {
   name: 'with buttons and links',
+}
+
+export const WithLoadingIndicator = () => {
+  const [isLoadingPrimary, setLoadingPrimary] = React.useState(false)
+  const [isLoadingSecondary, setLoadingSecondary] = React.useState(false)
+  const [isLoadingTertiary, setLoadingTertiary] = React.useState(false)
+
+  const handleClickPrimary = () => {
+    setLoadingPrimary(true)
+  }
+
+  const handleClickSecondary = () => {
+    setLoadingSecondary(true)
+  }
+
+  const handleClickTertiary = () => {
+    setLoadingTertiary(true)
+  }
+
+  React.useEffect(() => {
+    if (isLoadingPrimary || isLoadingSecondary || isLoadingTertiary) {
+      simulateNetworkRequest().then(() => {
+        setLoadingPrimary(false)
+        setLoadingSecondary(false)
+        setLoadingTertiary(false)
+      })
+    }
+  }, [isLoadingPrimary, isLoadingSecondary, isLoadingTertiary])
+
+  return (
+    <Actions>
+      <Button onClick={handleClickPrimary} isLoading={isLoadingPrimary}>
+        Save & close
+      </Button>
+      <Button
+        onClick={handleClickSecondary}
+        isLoading={isLoadingSecondary}
+        variant="secondary"
+      >
+        Save
+      </Button>
+      <TextLinkButton
+        onClick={handleClickTertiary}
+        isLoading={isLoadingTertiary}
+      >
+        Cancel
+      </TextLinkButton>
+    </Actions>
+  )
+}
+WithLoadingIndicator.story = {
+  name: 'with loading indicator',
 }

--- a/src/components/Actions/index.stories.jsx
+++ b/src/components/Actions/index.stories.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import Button from '../Button'
 import TextLink from '../TextLink'
+import TextLinkButton from '../TextLinkButton'
 
 import Actions from './index'
 
@@ -32,7 +33,19 @@ WithTextLink.story = {
   name: 'with TextLink',
 }
 
-export const WithBoth = () => {
+export const WithTextLinkButton = () => {
+  return (
+    <Actions>
+      <Button>Submit</Button>
+      <TextLinkButton onClick="#">Cancel</TextLinkButton>
+    </Actions>
+  )
+}
+WithTextLinkButton.story = {
+  name: 'with TextLinkButton',
+}
+
+export const WithButtonsAndLink = () => {
   return (
     <Actions>
       <Button>Save & Close</Button>
@@ -41,6 +54,6 @@ export const WithBoth = () => {
     </Actions>
   )
 }
-WithBoth.story = {
-  name: 'with both',
+WithButtonsAndLink.story = {
+  name: 'with buttons and links',
 }

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -73,7 +73,7 @@ const Base = styled('button')(
   })
 )
 
-const Loader = styled.span`
+export const Loader = styled.span`
   display: 'inline-block';
 
   & > span {

--- a/src/components/TextLink/index.jsx
+++ b/src/components/TextLink/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import { styled, createShouldForwardProp, props, sx } from '../../util/style'
 import ActionsContext from '../Actions/ActionsContext'
 import Box from '../Box'
+import { Loader } from '../Button'
 
 const shouldForwardProp = createShouldForwardProp([
   ...props,
@@ -73,9 +74,8 @@ const BaseLink = styled('a', { shouldForwardProp })(
   sx
 )
 
-const TextLink = forwardRef((props, ref) => {
+const TextLink = forwardRef(({ children, icon, isLoading, ...props }, ref) => {
   const actionsContext = useContext(ActionsContext)
-  const { children, icon } = props
 
   return (
     <BaseLink ref={ref} isNestedInActions={actionsContext != null} {...props}>
@@ -85,6 +85,13 @@ const TextLink = forwardRef((props, ref) => {
         </Box>
       ) : null}
       {children}
+      {isLoading ? (
+        <Loader aria-hidden>
+          <span />
+          <span />
+          <span />
+        </Loader>
+      ) : null}
     </BaseLink>
   )
 })
@@ -100,11 +107,14 @@ TextLink.propTypes = {
   icon: PropTypes.node,
   showVisited: PropTypes.bool,
   hitArea: PropTypes.oneOf(['standard', 'large']),
+  /** This doesn't make sense for normal links, but we need it for TextLinkButton to show progress on async onClick actions */
+  isLoading: PropTypes.bool,
 }
 
 TextLink.defaultProps = {
   showVisited: false,
   hitArea: 'standard',
+  isLoading: false,
 }
 
 export default TextLink

--- a/src/components/TextLinkButton/index.jsx
+++ b/src/components/TextLinkButton/index.jsx
@@ -1,75 +1,10 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
-import { styled } from '../../util/style'
 import TextLink from '../TextLink'
-import Box from '../Box'
-import ActionsContext from '../Actions/ActionsContext'
-
-const Loader = styled.span`
-  display: inline-flex;
-  font-size: inherit;
-  align-self: center;
-  padding-top: 10px;
-
-  & > span {
-    width: 0.15em;
-    height: 0.15em;
-    background-color: currentColor;
-    border-radius: 100%;
-    display: inline-block;
-    animation: loading-animation 1000ms infinite ease-in-out both;
-  }
-
-  & > span:nth-of-type(1) {
-    margin-left: 0.25em;
-    margin-right: 0.15em;
-    animation-delay: -320ms;
-  }
-
-  & > span:nth-of-type(2) {
-    margin-right: 0.15em;
-    animation-delay: -160ms;
-  }
-
-  @keyframes loading-animation {
-    0%,
-    80%,
-    100% {
-      transform: scale(0);
-    }
-
-    40% {
-      transform: scale(1);
-    }
-  }
-`
 
 const TextLinkButton = props => {
-  const actionsContext = useContext(ActionsContext)
-  const isNestedInActions = actionsContext != null
-
-  const { isLoading } = props
-  return (
-    <Box as="span" sx={{ display: isNestedInActions ? 'flex' : null }}>
-      <TextLink
-        as="span"
-        role="button"
-        tabIndex={0}
-        {...props}
-        style={{
-          fontSize: !!isNestedInActions ? 'inherit' : null,
-        }}
-      />
-      {isLoading ? (
-        <Loader isNestedInActions={isNestedInActions} aria-hidden>
-          <span />
-          <span />
-          <span />
-        </Loader>
-      ) : null}
-    </Box>
-  )
+  return <TextLink as="span" role="button" tabIndex={0} {...props} />
 }
 
 TextLinkButton.defaultProps = {

--- a/src/components/TextLinkButton/index.jsx
+++ b/src/components/TextLinkButton/index.jsx
@@ -3,8 +3,18 @@ import PropTypes from 'prop-types'
 
 import TextLink from '../TextLink'
 
-const TextLinkButton = props => {
-  return <TextLink as="span" role="button" tabIndex={0} {...props} />
+const TextLinkButton = ({ onClick, isLoading, children }) => {
+  return (
+    <TextLink
+      as="span"
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      isLoading={isLoading}
+    >
+      {children}
+    </TextLink>
+  )
 }
 
 TextLinkButton.defaultProps = {
@@ -13,6 +23,10 @@ TextLinkButton.defaultProps = {
 
 TextLinkButton.propTypes = {
   isLoading: PropTypes.bool,
+  // eslint-disable-next-line react/require-default-props
+  onClick: PropTypes.func,
+  // eslint-disable-next-line react/require-default-props
+  children: PropTypes.node,
 }
 
 export default TextLinkButton

--- a/src/components/TextLinkButton/index.stories.jsx
+++ b/src/components/TextLinkButton/index.stories.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-alert */
 import React from 'react'
 import { select } from '@storybook/addon-knobs'
 
@@ -50,10 +49,8 @@ Default.story = {
 export const InActions = () => {
   return (
     <Actions>
-      <Button>I want option 1</Button>
-      <TextLinkButton onClick={() => alert('clicked')}>
-        I want to opt out
-      </TextLinkButton>
+      <Button>Button</Button>
+      <TextLinkButton>TextLinkButton</TextLinkButton>
     </Actions>
   )
 }

--- a/src/components/TextLinkButton/index.stories.jsx
+++ b/src/components/TextLinkButton/index.stories.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-alert */
-import React, { useState } from 'react'
+import React from 'react'
 import { select } from '@storybook/addon-knobs'
 
 import Text from '../Text'
@@ -47,35 +47,16 @@ Default.story = {
   name: 'default',
 }
 
-export const WithActions = () => {
-  const [loading, setLoading] = useState(true)
-  const hitArea = select('Hit Area', ['standard', 'large'], 'standard')
-  const size = select(
-    'Text Size',
-    ['tiny', 'small', 'standard', 'large'],
-    'standard'
-  )
+export const InActions = () => {
   return (
     <Actions>
-      <Button size={size}>I want option 1</Button>
-      <Text size={size}>
-        <TextLinkButton
-          onClick={() => {
-            setLoading(true)
-            setTimeout(function () {
-              setLoading(false)
-              alert('Hello there!')
-            }, 2000)
-          }}
-          hitArea={hitArea}
-          isLoading={loading}
-        >
-          I want to opt out
-        </TextLinkButton>{' '}
-      </Text>
+      <Button>I want option 1</Button>
+      <TextLinkButton onClick={() => alert('clicked')}>
+        I want to opt out
+      </TextLinkButton>
     </Actions>
   )
 }
-WithActions.story = {
-  name: 'with Actions',
+InActions.story = {
+  name: 'inside Actions',
 }


### PR DESCRIPTION
We recently noticed that `TextLinkButton` is missing the same visual loading indicator we have for `Button`. This was added in #176, but in a way that introduced avoidable complexity and needed fixing in #177. This PR here first resets `TextLinkButton` to a state before the two mentioned PRs and then re-implements the desired changes.

# Why?
The current implementation has a few flaws:

1. We lose the `ref` on `TextLinkButton` because it's never forwarded. This is fixed by adding the changes to the underlying `TextLink` instead, where we take care of forwarding the `ref`.
2. We mess up the semantics because `TextLinkButton` currently needs an additional wrapper. Fixed in the same way as above.
3. The complexity that needed to be addressed in #177 is entirely avoidable—the same fix as above.
4. This somehow broke the `font-size` when using `TextLinkButton` inside `Actions` (see screenshot below)

## Correct `font-size`
![image](https://user-images.githubusercontent.com/6179211/133986572-8ddbe372-fe80-4e21-a19b-7977c0bad40a.png)

## Current, incorrect `font-size`
![image](https://user-images.githubusercontent.com/6179211/133986588-2eb366f4-8bd2-4a6b-9ebc-983dcd6b6ffa.png)

# How to test

Look at [this new story that shows how loading indicators look for `Button` and `TextLinkButton`](https://deploy-preview-179--qualifyze-storybook.netlify.app/?path=/story/actions--with-loading-indicator).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/179)
<!-- Reviewable:end -->
