### PR TITLE
Prevent undesired focus styles w/ `focus-visible`

### DIFF
--- a/.changeset/clean-readers-deliver.md
+++ b/.changeset/clean-readers-deliver.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Prevent undesired focus styles when using a mouse

--- a/src/util/style/resetCSS.js
+++ b/src/util/style/resetCSS.js
@@ -97,4 +97,11 @@ export const resetCSS = css`
       scroll-behavior: auto !important;
     }
   }
+
+  /* Prevent undesired focus styles when not using a keyboard for all browsers that support it. See: https://www.tpgi.com/focus-visible-and-backwards-compatibility/ */
+  *:focus:not(:focus-visible) {
+    outline: none !important;
+    box-shadow: none !important;
+    border: none !important;
+  }
 `


### PR DESCRIPTION
We used `:focus` styles for pretty much everything, which is great at
first because it provides a more accessible experience for users that
use keyboards. However, sometimes `:focus` adds styling even when the
browser thinks the focus styles shouldn't be visible. This is why most
vendors have added `:focus-visible` by now, which is generally better
for adding keyboard-specific styles. Since Safari and IE11 don't support
it yet, we need to disable the undesired styles added by `:focus` only
for these browsers that support `:focus-visible`.

More reading: https://www.tpgi.com/focus-visible-and-backwards-compatibility/

# How to test

You can compare the "Actions -> with Buttons" story between [the current version](https://qualifyze-storybook.netlify.app/?path=/story/actions--with-buttons) and [this PR](https://deploy-preview-180--qualifyze-storybook.netlify.app/?path=/story/actions--with-buttons). You will see that the focus styles (the blue outline) will not get added when you click the buttons with a mouse. When using a keyboard, they will still be visible. The desired focus styles should remain untouched and should still be added when navigating with a keyboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/180)
<!-- Reviewable:end -->
