### PR TITLE
Change level for Modal Heading from 4 to 3

### DIFF
--- a/.changeset/silent-mice-eat.md
+++ b/.changeset/silent-mice-eat.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Change Modal.Heading level from 4 to 3

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -16,7 +16,7 @@ import Icon from '../Icon'
 // eslint-disable-next-line react/prop-types
 const Heading = ({ children }) => (
   <Box sx={{ px: 3, pt: 3, pb: 3, mr: '44px' }}>
-    <BaseHeading as="span" level={4} weight="weak">
+    <BaseHeading as="span" level={3} weight="weak">
       {children}
     </BaseHeading>
   </Box>


### PR DESCRIPTION
In order to signal a better hierarchy of information: We want to state this one a 3 so forms inside the modal can use Heading level 4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/195)
<!-- Reviewable:end -->
