### PR TITLE
Fix missing key press handling on `TextLinkButton`

### DIFF
--- a/.changeset/giant-pots-tickle.md
+++ b/.changeset/giant-pots-tickle.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Fix missing keypress handlers on `TextLinkButton`

--- a/src/components/TextLinkButton/index.jsx
+++ b/src/components/TextLinkButton/index.jsx
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types'
 import TextLink from '../TextLink'
 
 const TextLinkButton = ({ onClick, isLoading, icon, children }) => {
+  const handleKeyPress = React.useCallback(event => {
+    if (event.code === 'Enter' || event.code === 'Space') {
+      onClick()
+    }
+  })
+
   return (
     <TextLink
       as="span"
@@ -12,6 +18,7 @@ const TextLinkButton = ({ onClick, isLoading, icon, children }) => {
       onClick={onClick}
       isLoading={isLoading}
       icon={icon}
+      onKeyPress={handleKeyPress}
     >
       {children}
     </TextLink>


### PR DESCRIPTION
We use a `<div role="button"` for `TextLinkButton` so that we can use it
within a block of text because this makes it an inline element.

However, when doing that, we missed to add key press handlers for Space
and Enter, which are required per spec:
https://www.w3.org/TR/wai-aria-practices/examples/button/button.html

Basically, normal buttons get triggered by pressing Space or Enter when
they are focused and you TextLinkButton should do that, too. This PR
does exactly that.

# How to test

1. Look at [this story in current production](https://qualifyze-storybook.netlify.app/?path=/story/textlinkbutton--loading), use your keyboard to move focus to the link, and press Enter or Space. Nothing should happen.
2. Then, look at [the same story in this branch](https://deploy-preview-203--qualifyze-storybook.netlify.app/?path=/story/textlinkbutton--loading), use your keyboard to move focus to the link, and press Enter or Space. The `onClick` should be triggered and you should see the loading animation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/203)
<!-- Reviewable:end -->
