### PR TITLE
Disable `TextLinkButton` when `isLoading` is true

### DIFF
--- a/.changeset/bright-spies-return.md
+++ b/.changeset/bright-spies-return.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Disable `TextLinkButton` when `isLoading` prop is `true`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualifyze/design-system",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualifyze/design-system",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": "10.1.1",

--- a/src/components/TextLinkButton/index.jsx
+++ b/src/components/TextLinkButton/index.jsx
@@ -4,18 +4,21 @@ import PropTypes from 'prop-types'
 import TextLink from '../TextLink'
 
 const TextLinkButton = ({ onClick, isLoading, icon, children }) => {
-  const handleKeyPress = React.useCallback(event => {
-    if (event.code === 'Enter' || event.code === 'Space') {
-      onClick()
-    }
-  })
+  const handleKeyPress = React.useCallback(
+    event => {
+      if (!isLoading && (event.code === 'Enter' || event.code === 'Space')) {
+        onClick?.()
+      }
+    },
+    [isLoading, onClick]
+  )
 
   return (
     <TextLink
       as="span"
       role="button"
       tabIndex={0}
-      onClick={onClick}
+      onClick={isLoading ? undefined : onClick}
       isLoading={isLoading}
       icon={icon}
       onKeyPress={handleKeyPress}


### PR DESCRIPTION
We do this for `Button` so this aligns behaviors between the two.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/204)
<!-- Reviewable:end -->
