### PR TITLE
AppBar: fix error when passing null children

### DIFF
--- a/.changeset/moody-cherries-perform.md
+++ b/.changeset/moody-cherries-perform.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+AppBar: fix error when passing null children

--- a/src/components/AppBar/index.jsx
+++ b/src/components/AppBar/index.jsx
@@ -36,41 +36,46 @@ function selectElements(elements) {
   if (elements) {
     for (let i = 0; i < elements.length; i += 1) {
       const element = elements[i]
-      const type = element.type.name
 
-      if (type === 'AppBarLogo') {
-        if (logo) {
-          throw new Error('You can only have one <AppBar.Logo /> child.')
+      if (element) {
+        const type = element.type.name
+
+        if (type === 'AppBarLogo') {
+          if (logo) {
+            throw new Error('You can only have one <AppBar.Logo /> child.')
+          }
+          logo = element
+        } else if (type === 'AppBarPrimaryNav') {
+          if (primaryNav) {
+            throw new Error(
+              'You can only have one <AppBar.PrimaryNav /> child.'
+            )
+          }
+          primaryNav = element
+        } else if (type === 'AppBarSecondaryNav') {
+          if (secondaryNav) {
+            throw new Error(
+              'You can only have one <AppBar.SecondaryNav /> child.'
+            )
+          }
+          secondaryNav = element
+        } else if (type === 'AppBarPrimaryActions') {
+          if (primaryActions) {
+            throw new Error(
+              'You can only have one <AppBar.PrimaryActions /> child.'
+            )
+          }
+          primaryActions = element
+        } else if (type === 'AppBarSecondaryActions') {
+          if (secondaryActions) {
+            throw new Error(
+              'You can only have one <AppBar.SecondaryActions /> child.'
+            )
+          }
+          secondaryActions = element
+        } else {
+          throw new Error('Unexpected child in AppBar:', element)
         }
-        logo = element
-      } else if (type === 'AppBarPrimaryNav') {
-        if (primaryNav) {
-          throw new Error('You can only have one <AppBar.PrimaryNav /> child.')
-        }
-        primaryNav = element
-      } else if (type === 'AppBarSecondaryNav') {
-        if (secondaryNav) {
-          throw new Error(
-            'You can only have one <AppBar.SecondaryNav /> child.'
-          )
-        }
-        secondaryNav = element
-      } else if (type === 'AppBarPrimaryActions') {
-        if (primaryActions) {
-          throw new Error(
-            'You can only have one <AppBar.PrimaryActions /> child.'
-          )
-        }
-        primaryActions = element
-      } else if (type === 'AppBarSecondaryActions') {
-        if (secondaryActions) {
-          throw new Error(
-            'You can only have one <AppBar.SecondaryActions /> child.'
-          )
-        }
-        secondaryActions = element
-      } else {
-        throw new Error('Unexpected child in AppBar:', element)
       }
     }
   }


### PR DESCRIPTION
Fixes an error that occurred when passing `falsy` children to AppBar:

```
<AppBar>
  {something && <AppBar.PrimaryNav />}
</AppBar>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/209)
<!-- Reviewable:end -->
