### PR TITLE
AppBar: fix handling of children

### DIFF
--- a/.changeset/few-falcons-jump.md
+++ b/.changeset/few-falcons-jump.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+AppBar: fix an error with the handling of children

--- a/src/components/AppBar/index.jsx
+++ b/src/components/AppBar/index.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useMemo } from 'react'
+import React, { Children, useMemo } from 'react'
 
 import { theme, ThemeProvider } from '../../util/style'
 import Box from '../Box'
@@ -34,9 +34,7 @@ function selectElements(elements) {
   let secondaryActions = null
 
   if (elements) {
-    for (let i = 0; i < elements.length; i += 1) {
-      const element = elements[i]
-
+    Children.forEach(elements, element => {
       if (element) {
         const type = element.type.name
 
@@ -77,7 +75,7 @@ function selectElements(elements) {
           throw new Error('Unexpected child in AppBar:', element)
         }
       }
-    }
+    })
   }
 
   return { logo, primaryActions, secondaryActions, primaryNav, secondaryNav }


### PR DESCRIPTION
Fix an error when using nested arrays as children of the app bar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/211)
<!-- Reviewable:end -->
