### PR TITLE
AppBar: fix padding for actions when there is no secondary nav

### DIFF
--- a/.changeset/few-candles-judge.md
+++ b/.changeset/few-candles-judge.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+AppBar: fix padding for actions when there is no secondary nav

--- a/src/components/AppBar/Nav.jsx
+++ b/src/components/AppBar/Nav.jsx
@@ -5,7 +5,7 @@ import Box from '../Box'
 
 import { useAppBarContext } from './context'
 
-export default function Nav({ align, children }) {
+export default function Nav({ align, padRight, children }) {
   const { collapsed } = useAppBarContext()
 
   return (
@@ -17,6 +17,7 @@ export default function Nav({ align, children }) {
         flexDirection: 'inherit',
         ml: !collapsed && align === 'right' ? 'auto' : 0,
         my: collapsed ? 2 : 0,
+        pr: !collapsed && padRight ? 3 : 0,
         width: collapsed ? '100%' : 'auto',
       }}
     >
@@ -27,10 +28,12 @@ export default function Nav({ align, children }) {
 
 Nav.propTypes = {
   align: PropTypes.oneOf(['left', 'right']),
+  padRight: PropTypes.bool,
   children: PropTypes.node,
 }
 
 Nav.defaultProps = {
   align: 'left',
+  padRight: false,
   children: null,
 }

--- a/src/components/AppBar/index.jsx
+++ b/src/components/AppBar/index.jsx
@@ -154,7 +154,7 @@ function AppBarContent({ position, children: elements }) {
               {secondaryNav && <Nav>{secondaryNav}</Nav>}
             </>
           ) : (
-            <Nav align="right">
+            <Nav align="right" padRight={!secondaryNav}>
               {primaryActions && <NavActions>{primaryActions}</NavActions>}
               {secondaryActions && <NavActions>{secondaryActions}</NavActions>}
               {secondaryNav}

--- a/src/components/AppBar/index.stories.jsx
+++ b/src/components/AppBar/index.stories.jsx
@@ -1,4 +1,4 @@
-import { select } from '@storybook/addon-knobs'
+import { boolean, number, select } from '@storybook/addon-knobs'
 import React from 'react'
 
 import Box from '../Box'
@@ -16,28 +16,45 @@ export const Default = () => {
   )
 
   const collapseBelow = select(
-    'collapseBelow',
+    'collapse below',
     { small: 'small', medium: 'medium', large: 'large' },
     'medium'
   )
+
+  const numberOfNavItems = number('number of nav items', 2, { min: 0 })
+
+  const primaryAction = boolean('primary action', true)
+  const secondaryAction = boolean('secondary action', true)
+  const secondaryNav = boolean('secondary nav item', true)
 
   return (
     <>
       <AppBar position={position} collapseBelow={collapseBelow}>
         <AppBar.Logo>Logo</AppBar.Logo>
-        <AppBar.PrimaryNav>
-          <AppBar.NavItem active>Page #1</AppBar.NavItem>
-          <AppBar.NavItem>Page #2</AppBar.NavItem>
-        </AppBar.PrimaryNav>
-        <AppBar.SecondaryNav>
-          <AppBar.NavItem>Secondary Nav</AppBar.NavItem>
-        </AppBar.SecondaryNav>
-        <AppBar.PrimaryActions>
-          <AppBar.Button>Primary Action</AppBar.Button>
-        </AppBar.PrimaryActions>
-        <AppBar.SecondaryActions>
-          <AppBar.Button variant="secondary">Secondary Action</AppBar.Button>
-        </AppBar.SecondaryActions>
+        {numberOfNavItems > 0 && (
+          <AppBar.PrimaryNav>
+            {Array.from(Array(numberOfNavItems).keys()).map(i => (
+              <AppBar.NavItem key={i} active={i === 0}>
+                Page #{i + 1}
+              </AppBar.NavItem>
+            ))}
+          </AppBar.PrimaryNav>
+        )}
+        {secondaryNav && (
+          <AppBar.SecondaryNav>
+            <AppBar.NavMenuItem label="Secondary" />
+          </AppBar.SecondaryNav>
+        )}
+        {primaryAction && (
+          <AppBar.PrimaryActions>
+            <AppBar.Button>Primary Action</AppBar.Button>
+          </AppBar.PrimaryActions>
+        )}
+        {secondaryAction && (
+          <AppBar.SecondaryActions>
+            <AppBar.Button variant="secondary">Secondary Action</AppBar.Button>
+          </AppBar.SecondaryActions>
+        )}
       </AppBar>
       <Box as="main" sx={{ p: 4, mt: position === 'fixed' ? 70 : 0 }}>
         <LoremIpsum paragraphs={12} />


### PR DESCRIPTION
When there's no secondary navigation (ie. the profile dropdown), then the actions stick to the right edge without a padding. This PR adds a padding for this scenario.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/212)
<!-- Reviewable:end -->
