### PR TITLE
AutosuggestField: enable setting of initial value

### DIFF
--- a/.changeset/tiny-shoes-jog.md
+++ b/.changeset/tiny-shoes-jog.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+AutosuggestField: enable setting of initial value

--- a/src/components/AutosuggestField/index.jsx
+++ b/src/components/AutosuggestField/index.jsx
@@ -80,7 +80,7 @@ const Menu = styled('ul')(props => ({
   visibility: props.isHidden ? 'hidden' : null,
 }))
 
-const extractText = item => (item ? item.text : '')
+const extractText = item => item?.text ?? ''
 
 const filterByContains = (items, value) =>
   items.filter(item => {
@@ -112,13 +112,13 @@ const AutosuggestField = ({
   const [inputSuggestions, setInputSuggestions] = useState(
     suggestions.slice(0, maxNumberOfSuggestionsToDisplay)
   )
-  const [field, meta, helpers] = useField({ name })
-  const { setValue, setTouched } = helpers
+  const [field, meta, { setValue, setTouched }] = useField({ name })
 
   const hasError = meta.error && meta.touched
-  const messageToShow = hasError
-    ? `${meta.error?.text.charAt(0).toUpperCase()}${meta.error?.text.slice(1)}`
-    : message ?? null
+  const messageToShow =
+    hasError && meta.error.text
+      ? `${meta.error.text.charAt(0).toUpperCase()}${meta.error.text.slice(1)}`
+      : message ?? null
 
   const {
     isOpen,
@@ -132,6 +132,7 @@ const AutosuggestField = ({
   } = useCombobox({
     items: inputSuggestions,
     itemToString: extractText,
+    initialSelectedItem: field.value,
     onInputValueChange: ({ inputValue, selectedItem }) => {
       // Once an item is selected, you can't change the value unless you select
       // another item. Then, if the user deletes a letter, the value won't be
@@ -151,6 +152,7 @@ const AutosuggestField = ({
       )
     },
   })
+
   return (
     <Box {...getComboboxProps()}>
       <FieldLabel

--- a/src/components/AutosuggestField/index.stories.jsx
+++ b/src/components/AutosuggestField/index.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { text, number } from '@storybook/addon-knobs'
+import { text, number, boolean } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 import { Formik, Form } from 'formik'
 import * as Yup from 'yup'
@@ -20,6 +20,7 @@ export const Default = () => {
   const secondaryLabel = text('Secondary Label', 'no Star Trek')
   const tertiaryLabel = text('Tertiary Label', 'Need help?')
   const maxNumberOfSuggestionsToDisplay = number('How much to display?', 5)
+  const initial = boolean('Set initial value', false)
   const movies = [
     {
       text: 'The Phantom Menace',
@@ -65,10 +66,9 @@ export const Default = () => {
 
   return (
     <Formik
+      key={initial}
       initialValues={{
-        movie: {
-          text: '',
-        },
+        movie: initial ? movies[0] : { text: '' },
       }}
       onSubmit={values => {
         action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
@@ -86,24 +86,22 @@ export const Default = () => {
         }),
       })}
     >
-      {() => (
-        <Form>
-          <AutosuggestField
-            name="movie"
-            label={label}
-            message={message}
-            secondaryLabel={secondaryLabel}
-            tertiaryLabel={
-              <TextLink href="https://en.wikipedia.org/wiki/List_of_Star_Wars_films#Skywalker_saga">
-                {tertiaryLabel}
-              </TextLink>
-            }
-            suggestions={movies}
-            maxNumberOfSuggestionsToDisplay={maxNumberOfSuggestionsToDisplay}
-          />
-          <FormDebugger />
-        </Form>
-      )}
+      <Form>
+        <AutosuggestField
+          name="movie"
+          label={label}
+          message={message}
+          secondaryLabel={secondaryLabel}
+          tertiaryLabel={
+            <TextLink href="https://en.wikipedia.org/wiki/List_of_Star_Wars_films#Skywalker_saga">
+              {tertiaryLabel}
+            </TextLink>
+          }
+          suggestions={movies}
+          maxNumberOfSuggestionsToDisplay={maxNumberOfSuggestionsToDisplay}
+        />
+        <FormDebugger />
+      </Form>
     </Formik>
   )
 }


### PR DESCRIPTION
The AutosuggestField now display the initial value in the form, if set. I've also fixed a bug with the error message, when the error message is empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/217)
<!-- Reviewable:end -->
