### PR TITLE
Autosuggest: react to external changes of the field value

### DIFF
--- a/.changeset/unlucky-carpets-fry.md
+++ b/.changeset/unlucky-carpets-fry.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Autosuggest: react to external changes of the field value

--- a/src/components/AutosuggestField/index.jsx
+++ b/src/components/AutosuggestField/index.jsx
@@ -132,7 +132,7 @@ const AutosuggestField = ({
   } = useCombobox({
     items: inputSuggestions,
     itemToString: extractText,
-    initialSelectedItem: field.value,
+    selectedItem: field.value,
     onInputValueChange: ({ inputValue, selectedItem }) => {
       // Once an item is selected, you can't change the value unless you select
       // another item. Then, if the user deletes a letter, the value won't be

--- a/src/components/AutosuggestField/index.stories.jsx
+++ b/src/components/AutosuggestField/index.stories.jsx
@@ -1,11 +1,13 @@
-import React from 'react'
+import React, { useCallback } from 'react'
+import PropTypes from 'prop-types'
 import { text, number, boolean } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
-import { Formik, Form } from 'formik'
+import { Formik, Form, useFormikContext } from 'formik'
 import * as Yup from 'yup'
 
 import TextLink from '../TextLink'
 import FormDebugger from '../FormDebugger'
+import Box from '../Box'
 
 import AutosuggestField from './index'
 
@@ -100,11 +102,54 @@ export const Default = () => {
           suggestions={movies}
           maxNumberOfSuggestionsToDisplay={maxNumberOfSuggestionsToDisplay}
         />
+        <MovieSelector movies={movies} />
         <FormDebugger />
       </Form>
     </Formik>
   )
 }
+
+function MovieSelector({ movies }) {
+  const { setFieldValue } = useFormikContext()
+  const onSelect = useCallback(
+    e => {
+      if (e.currentTarget.value) {
+        const movie = movies[parseInt(e.currentTarget.value, 10)]
+        setFieldValue('movie', movie)
+        e.currentTarget.value = ''
+      }
+    },
+    [movies]
+  )
+
+  return (
+    <Box sx={{ my: 4 }}>
+      <p>
+        Manually select a movie to demonstrate how the autocomplete input reacts
+        to external state changes:
+      </p>
+      <select onChange={onSelect} defaultValue="">
+        <option value="" disabled>
+          [ select a movie ]
+        </option>
+        {movies.map((movie, index) => (
+          <option key={movie.value} value={index}>
+            {movie.text}
+          </option>
+        ))}
+      </select>
+    </Box>
+  )
+}
+MovieSelector.propTypes = {
+  movies: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.number.isRequired,
+      text: PropTypes.string.isRequired,
+    }).isRequired
+  ).isRequired,
+}
+
 Default.story = {
   name: 'default',
 }


### PR DESCRIPTION
The Autosuggest wouldn't react to updates of the field value outside of the component itself. This PR fixes this by converting the field into a controlled field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/219)
<!-- Reviewable:end -->
