### PR TITLE
Add `DangerAction` to `FileRow` and change styling

### DIFF
--- a/.changeset/polite-rabbits-dream.md
+++ b/.changeset/polite-rabbits-dream.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': minor
+---
+
+Add DangerAction to FileRow and change styling

--- a/src/components/FileRow/index.jsx
+++ b/src/components/FileRow/index.jsx
@@ -3,15 +3,18 @@ import PropTypes from 'prop-types'
 
 import Flex from '../Flex'
 import PrimaryAction from '../FileBox/PrimaryAction'
+import DangerAction from '../FileBox/DangerAction'
 
+// The styling of this should match with `src/components/FileUpload/File.jsx`
 const FileUploadRow = ({ text, children }) => {
   return (
     <Flex
       sx={{
         'borderRadius': theme => theme.radii[1],
         'flexDirection': 'column',
+        'boxShadow': theme => `inset 0 0 0 1px ${theme.colors.grey[500]}`,
         '&:hover, &:focus-within': {
-          bg: 'grey.100',
+          boxShadow: theme => `inset 0 0 0 1px ${theme.colors.grey[800]}`,
         },
         'p': 2,
       }}
@@ -39,6 +42,7 @@ const FileUploadRow = ({ text, children }) => {
 }
 
 FileUploadRow.PrimaryAction = PrimaryAction
+FileUploadRow.DangerAction = DangerAction
 FileUploadRow.propTypes = {
   text: PropTypes.string.isRequired,
   // eslint-disable-next-line react/require-default-props

--- a/src/components/FileRow/index.stories.jsx
+++ b/src/components/FileRow/index.stories.jsx
@@ -25,6 +25,11 @@ export const Default = () => {
       <Stack space="1">
         {files.map(file => (
           <FileRow key={file.name} text={file.name}>
+            <FileRow.DangerAction
+              iconName="trash"
+              // eslint-disable-next-line no-alert
+              onClick={() => alert("I'm supposed to be delete this file")}
+            />
             <FileRow.PrimaryAction
               iconName="download"
               // eslint-disable-next-line no-alert

--- a/src/components/FileUpload/File.jsx
+++ b/src/components/FileUpload/File.jsx
@@ -5,6 +5,7 @@ import { getIn, useFormikContext } from 'formik'
 import Flex from '../Flex'
 import FieldMessage from '../FieldMessage'
 
+// The styling of this should match with `src/components/FileRow/index.jsx`
 const FileUploadRow = ({ text, name, index, children }) => {
   const { errors: formErrors } = useFormikContext()
   const fieldErrors = getIn(formErrors, `${name}.${index}`)
@@ -17,13 +18,17 @@ const FileUploadRow = ({ text, name, index, children }) => {
       sx={{
         'borderRadius': theme => theme.radii[1],
         'boxShadow': theme =>
-          !!errors ? `inset 0 0 0 2px ${theme.colors.red[500]}` : null,
+          !!errors
+            ? `inset 0 0 0 2px ${theme.colors.red[500]}`
+            : `inset 0 0 0 1px ${theme.colors.grey[500]}`,
         'bg': theme => (!!errors ? theme.colors.red[100] : null),
         'flexDirection': 'column',
         '&:hover, &:focus-within': {
-          bg: !!errors ? 'red.100' : 'grey.100',
+          bg: !!errors ? 'red.100' : 'transparent',
           boxShadow: theme =>
-            !!errors ? `inset 0 0 0 2px ${theme.colors.red[700]}` : null,
+            !!errors
+              ? `inset 0 0 0 2px ${theme.colors.red[700]}`
+              : `inset 0 0 0 1px ${theme.colors.grey[800]}`,
         },
         'p': 2,
       }}


### PR DESCRIPTION
`FileRow` was missing support to have a `DangerAction` so I added it.
We also want to replace its previous styling (background change on
hover) to have a border on hover.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/223)
<!-- Reviewable:end -->
