### PR TITLE
VE-104: Change cursor on file name for `FileRow`

### DIFF
--- a/.changeset/famous-poems-doubt.md
+++ b/.changeset/famous-poems-doubt.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+This changes the cursor of the Text on a FileRow component to be the default pointer.

--- a/src/components/FileRow/index.jsx
+++ b/src/components/FileRow/index.jsx
@@ -15,6 +15,7 @@ const FileUploadRow = ({ text, errors, children }) => {
           !!errors ? `inset 0 0 0 2px ${theme.colors.red[500]}` : null,
         'bg': theme => (!!errors ? theme.colors.red[100] : null),
         'flexDirection': 'column',
+        'cursor': 'default',
         '&:hover, &:focus-within': {
           bg: !!errors ? 'red.100' : 'grey.100',
           boxShadow: theme =>


### PR DESCRIPTION
This changes the cursor of the Text on a FileRow component to be the default pointer. Before, it would display the Text selection cursor when hovering the row, which looks strange in combination with the hover background

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualifyze/design-system/224)
<!-- Reviewable:end -->
