### PR TITLE
Quickfix: Fix the horizontal text alignment in `FileRow` component

### DIFF
--- a/.changeset/silly-pumpkins-sing.md
+++ b/.changeset/silly-pumpkins-sing.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Fix text alignment in FileRow component

--- a/src/components/FileRow/index.jsx
+++ b/src/components/FileRow/index.jsx
@@ -35,7 +35,7 @@ const FileUploadRow = ({ text, errors, children }) => {
           alignItems: 'stretch',
         }}
       >
-        <Flex sx={{ flex: 1, alignItems: 'center', color: 'grey.800' }}>
+        <Flex sx={{ flex: 1, alignSelf: 'center', color: 'grey.800' }}>
           {text}
         </Flex>
         <Flex


### PR DESCRIPTION
The text was not centered and therefore not in line with the actions