### PR TITLE
Do not use `<strong>` inside labels

### DIFF
--- a/.changeset/forty-eagles-promise.md
+++ b/.changeset/forty-eagles-promise.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Do not use `<strong>` inside form labels

--- a/src/components/FieldLabel/index.jsx
+++ b/src/components/FieldLabel/index.jsx
@@ -5,7 +5,6 @@ import Stack from '../Stack'
 import Box from '../Box'
 import Flex from '../Flex'
 import Text from '../Text'
-import Strong from '../Strong'
 
 const FieldLabel = ({
   htmlFor,
@@ -20,7 +19,9 @@ const FieldLabel = ({
 
   const labelElement = (
     <Text as="span">
-      <Strong>{label}</Strong>
+      <Box as="span" sx={{ fontWeight: 'semibold' }}>
+        {label}
+      </Box>
       {secondaryLabel ? (
         <Text as="span" color="grey.600">
           &nbsp;({secondaryLabel})


### PR DESCRIPTION
We were using a strong tag to make labels visually stronger, but I'm not
convinced this is semantically correct.