### PR TITLE
Quickfix: min width for the checkbox box

### DIFF
--- a/.changeset/pink-forks-sip.md
+++ b/.changeset/pink-forks-sip.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Add min width for the checkbox so it does not break with long text

--- a/src/components/Checkbox/index.jsx
+++ b/src/components/Checkbox/index.jsx
@@ -64,6 +64,7 @@ const Indicator = styled(Box)(
     alignItems: 'center',
     height: '24px',
     width: '24px',
+    minWidth: '24px',
     background: props.theme.colors.white,
     boxShadow: `inset 0 0 0 1px ${props.theme.colors.grey[400]}`,
     borderRadius: props.theme.radii[2],


### PR DESCRIPTION
# What❓

Just added a min width prop

# Why 💁‍♀️

When you add a ton of text the width of the box is not maintained:

![Screenshot 2022-01-18 at 17 58 32](https://user-images.githubusercontent.com/1426390/149985297-704a0fd4-fd19-412c-b1b3-6f8e339a32c0.png)


# How to test ✅

You can test it in story book


