### PR TITLE
Quickfix: checkbox for optional

### DIFF
--- a/.changeset/funny-seas-give.md
+++ b/.changeset/funny-seas-give.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Make the for prop optional on checkboxes

--- a/src/components/Checkbox/index.jsx
+++ b/src/components/Checkbox/index.jsx
@@ -7,7 +7,7 @@ import Icon from '../Icon'
 import Box from '../Box'
 import Text from '../Text'
 import FieldMessage from '../FieldMessage'
-import { styled, variant } from '../../util/style'
+import { propTypes, styled, variant } from '../../util/style'
 
 const Input = styled('input')(props => ({
   'outline': 'none',
@@ -94,7 +94,14 @@ const Indicator = styled(Box)(
   useDisabledStyles
 )
 
-const Checkbox = ({ name, label, disabled, reserveMessageSpace, size }) => {
+const Checkbox = ({
+  name,
+  label,
+  disabled,
+  reserveMessageSpace,
+  size,
+  withFor,
+}) => {
   const [field, meta] = useField({ name, type: 'checkbox' })
   const hasError = meta.error && meta.touched
 
@@ -123,7 +130,7 @@ const Checkbox = ({ name, label, disabled, reserveMessageSpace, size }) => {
             sx={{
               cursor: disabled ? 'default' : 'pointer',
             }}
-            htmlFor={name}
+            htmlFor={withFor ? name : ''}
           >
             <Text
               size={size}
@@ -154,12 +161,14 @@ Checkbox.propTypes = {
   /** Whether Checkbox is disabled */
   disabled: PropTypes.bool,
   reserveMessageSpace: PropTypes.bool,
+  withFor: propTypes.bool,
   size: PropTypes.oneOf(['tiny', 'small', 'standard', 'large']),
 }
 
 Checkbox.defaultProps = {
   disabled: false,
   reserveMessageSpace: false,
+  withFor: true,
   size: 'standard',
 }
 

--- a/src/components/Checkbox/index.stories.jsx
+++ b/src/components/Checkbox/index.stories.jsx
@@ -19,6 +19,7 @@ export const Default = () => {
   const label = text('Label', 'Sign me up for the newsletter')
   const size = select('Size', sizes, 'standard')
   const disabled = boolean('Disabled', false)
+  const withFor = boolean('With for', false)
   const error = boolean('Not false error', false)
   const insideState = boolean('Inside State', false)
 
@@ -50,6 +51,7 @@ export const Default = () => {
                 label={label}
                 size={size}
                 disabled={disabled}
+                withFor={withFor}
               />
               <Button type="submit" ml={5}>
                 Submit


### PR DESCRIPTION
# What❓

Make the for prop optional on the checkboxes

# Why 💁‍♀️

Here we make the for prop for the label that goes with the checkbox optional, so you can have things like links in the label

# How to test ✅

Check on story book the "with for" toggle
