### PR TITLE
Add additional text for the checkbox

### DIFF
--- a/.changeset/funny-seas-give.md
+++ b/.changeset/funny-seas-give.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Make the for prop optional on checkboxes

--- a/src/components/Checkbox/index.jsx
+++ b/src/components/Checkbox/index.jsx
@@ -7,7 +7,7 @@ import Icon from '../Icon'
 import Box from '../Box'
 import Text from '../Text'
 import FieldMessage from '../FieldMessage'
-import { propTypes, styled, variant } from '../../util/style'
+import { styled, variant } from '../../util/style'
 
 const Input = styled('input')(props => ({
   'outline': 'none',
@@ -76,16 +76,16 @@ const Indicator = styled(Box)(
     prop: 'size',
     variants: {
       tiny: {
-        marginTop: '-3px',
+        marginTop: '2px',
       },
       small: {
-        marginTop: '-1px',
+        marginTop: '2px',
       },
       standard: {
-        marginTop: '1px',
+        marginTop: '0px',
       },
       large: {
-        marginTop: '3px',
+        marginTop: '5px',
       },
     },
   }),
@@ -100,7 +100,7 @@ const Checkbox = ({
   disabled,
   reserveMessageSpace,
   size,
-  withFor,
+  additionalText,
 }) => {
   const [field, meta] = useField({ name, type: 'checkbox' })
   const hasError = meta.error && meta.touched
@@ -125,21 +125,32 @@ const Checkbox = ({
           >
             {meta.value && <Icon name="checkmark" color="white" />}
           </Indicator>
-          <Flex
-            as="label"
-            sx={{
-              cursor: disabled ? 'default' : 'pointer',
-            }}
-            htmlFor={withFor ? name : ''}
-          >
-            <Text
-              size={size}
-              as="span"
-              color={disabled ? 'grey.400' : 'grey.800'}
+          <Box sx={{ display: 'inline' }}>
+            <Box
+              as="label"
+              sx={{
+                cursor: disabled ? 'default' : 'pointer',
+              }}
+              htmlFor={name}
             >
-              {label}
-            </Text>
-          </Flex>
+              <Text
+                size={size}
+                as="span"
+                color={disabled ? 'grey.400' : 'grey.800'}
+              >
+                {label}
+              </Text>
+            </Box>
+            {additionalText ? (
+              <Text
+                size={size}
+                as="span"
+                color={disabled ? 'grey.400' : 'grey.800'}
+              >
+                {additionalText}
+              </Text>
+            ) : null}
+          </Box>
         </Flex>
       </Flex>
       {reserveMessageSpace || hasError ? (
@@ -161,15 +172,15 @@ Checkbox.propTypes = {
   /** Whether Checkbox is disabled */
   disabled: PropTypes.bool,
   reserveMessageSpace: PropTypes.bool,
-  withFor: propTypes.bool,
   size: PropTypes.oneOf(['tiny', 'small', 'standard', 'large']),
+  additionalText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 }
 
 Checkbox.defaultProps = {
   disabled: false,
   reserveMessageSpace: false,
-  withFor: true,
   size: 'standard',
+  additionalText: '',
 }
 
 export default Checkbox

--- a/src/components/Checkbox/index.jsx
+++ b/src/components/Checkbox/index.jsx
@@ -7,7 +7,7 @@ import Icon from '../Icon'
 import Box from '../Box'
 import Text from '../Text'
 import FieldMessage from '../FieldMessage'
-import { styled, variant } from '../../util/style'
+import { propTypes, styled, variant } from '../../util/style'
 
 const Input = styled('input')(props => ({
   'outline': 'none',
@@ -94,7 +94,14 @@ const Indicator = styled(Box)(
   useDisabledStyles
 )
 
-const Checkbox = ({ name, label, disabled, reserveMessageSpace, size }) => {
+const Checkbox = ({
+  name,
+  label,
+  disabled,
+  reserveMessageSpace,
+  size,
+  withFor,
+}) => {
   const [field, meta] = useField({ name, type: 'checkbox' })
   const hasError = meta.error && meta.touched
 
@@ -123,7 +130,7 @@ const Checkbox = ({ name, label, disabled, reserveMessageSpace, size }) => {
             sx={{
               cursor: disabled ? 'default' : 'pointer',
             }}
-            htmlFor={name}
+            htmlFor={withFor ? name : ''}
           >
             <Text
               size={size}
@@ -154,12 +161,14 @@ Checkbox.propTypes = {
   /** Whether Checkbox is disabled */
   disabled: PropTypes.bool,
   reserveMessageSpace: PropTypes.bool,
+  withFor: propTypes.bool,
   size: PropTypes.oneOf(['tiny', 'small', 'standard', 'large']),
 }
 
 Checkbox.defaultProps = {
   disabled: false,
   reserveMessageSpace: false,
+  withFor: true,
   size: 'standard',
 }
 

--- a/src/components/Checkbox/index.stories.jsx
+++ b/src/components/Checkbox/index.stories.jsx
@@ -19,6 +19,7 @@ export const Default = () => {
   const label = text('Label', 'Sign me up for the newsletter')
   const size = select('Size', sizes, 'standard')
   const disabled = boolean('Disabled', false)
+  const withFor = boolean('With for', false)
   const error = boolean('Not false error', false)
   const insideState = boolean('Inside State', false)
 
@@ -50,6 +51,7 @@ export const Default = () => {
                 label={label}
                 size={size}
                 disabled={disabled}
+                withFor={withFor}
               />
               <Button type="submit" ml={5}>
                 Submit

--- a/src/components/Checkbox/index.stories.jsx
+++ b/src/components/Checkbox/index.stories.jsx
@@ -8,6 +8,7 @@ import Button from '../Button'
 import FormDebugger from '../FormDebugger'
 import Box from '../Box'
 import Stack from '../Stack'
+import TextLink from '../TextLink'
 
 import Checkbox from './index'
 
@@ -15,11 +16,12 @@ export default { title: 'Checkbox', component: Checkbox }
 
 export const Default = () => {
   const sizes = ['tiny', 'small', 'standard', 'large']
+  const extraTexts = ['text', 'text_and_link']
 
   const label = text('Label', 'Sign me up for the newsletter')
   const size = select('Size', sizes, 'standard')
   const disabled = boolean('Disabled', false)
-  const withFor = boolean('With for', false)
+  const additionalText = select('Additional text', extraTexts, 'text')
   const error = boolean('Not false error', false)
   const insideState = boolean('Inside State', false)
 
@@ -30,6 +32,7 @@ export const Default = () => {
   const checkboxSchemaEmpty = Yup.object().shape({
     newsletter: Yup.boolean().required(),
   })
+
   return (
     <Box m={5}>
       <Formik
@@ -51,7 +54,15 @@ export const Default = () => {
                 label={label}
                 size={size}
                 disabled={disabled}
-                withFor={withFor}
+                additionalText={
+                  additionalText === 'text' ? (
+                    ' this is some text on the end of the select'
+                  ) : (
+                    <>
+                      {` this is some text`} <TextLink>with a link</TextLink>
+                    </>
+                  )
+                }
               />
               <Button type="submit" ml={5}>
                 Submit


### PR DESCRIPTION
# What❓

I have added an optional prop on the checkbox which will allow you to pass in text on the end. after the label

# Why 💁‍♀️

We want to have links right after legal copy, we don't want to put them in the label as that is not accessible but we do want them to flow well with the text next to the checkbox so it all looks like part of the same copy

# How to test ✅

I have added a new option in story book for checkbox so you can play with the new "additional text" param. and you can see how it would work with some text and an object like a react component.

the reason we want to support a react component is because we could have links in there for example. But maybe you also just want to add some plain old text on the end that would not trigger the checkbox?


