### PR TITLE
Quickfix/focus broken for checkbox

### DIFF
--- a/.changeset/gorgeous-buttons-notice.md
+++ b/.changeset/gorgeous-buttons-notice.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Focus on checkbox label was not correct with introduction of additional text

--- a/src/components/Checkbox/index.jsx
+++ b/src/components/Checkbox/index.jsx
@@ -125,7 +125,7 @@ const Checkbox = ({
           >
             {meta.value && <Icon name="checkmark" color="white" />}
           </Indicator>
-          <Box sx={{ display: 'inline' }}>
+          <Box sx={{ display: 'inline' }} as="span">
             <Box
               as="label"
               sx={{


### PR DESCRIPTION
# What❓

Focus on the label for checkbox was broken

# Why 💁‍♀️

Css targeted all divs, we added a new div to get inline behaviour of additional text. we had to resolve that

# How to test ✅

You can check in story book there is no focus on the label text anymore for the checkbox

