### PR TITLE
Remove focus rules from reset css in the DS

### DIFF
--- a/.changeset/late-beans-prove.md
+++ b/.changeset/late-beans-prove.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Remove reset styles that break dropdown menu

--- a/src/util/style/resetCSS.js
+++ b/src/util/style/resetCSS.js
@@ -97,11 +97,4 @@ export const resetCSS = css`
       scroll-behavior: auto !important;
     }
   }
-
-  /* Prevent undesired focus styles when not using a keyboard for all browsers that support it. See: https://www.tpgi.com/focus-visible-and-backwards-compatibility/ */
-  *:focus:not(:focus-visible) {
-    outline: none !important;
-    box-shadow: none !important;
-    border: none !important;
-  }
 `


### PR DESCRIPTION
# What❓

I have removed the global rules in the reset with regards to focus and removing the border and box shadow

# Why 💁‍♀️

For our dropdown component there are cases when the shadow is just removed, the more we use this. the more we see it.

Right now you can see it big time in two places:

- nav dropdown
- organisation members list


# How to test ✅

I found that the error only happens when there are some redraws of the UI. so to test it have a look at the story book on next. play with the app bar dropdown and do the following

click the profile
click one of the nav links 
click the profile again

the second time the shadow is broken

do the same thing in story book on this branch, the error is fixed
