### PR TITLE
Fix shadows of `DropdownMenu`

### DIFF
--- a/.changeset/sixty-otters-cough.md
+++ b/.changeset/sixty-otters-cough.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Fix shadows of `DropdownMenu`

--- a/src/components/DropdownMenu/index.jsx
+++ b/src/components/DropdownMenu/index.jsx
@@ -3,13 +3,20 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import { styled } from '../../util/style'
 
 const StyledContent = styled(DropdownMenuPrimitive.Content)(props => ({
-  minWidth: '100px',
-  backgroundColor: props.theme.colors.white,
-  borderRadius: props.theme.radii[2],
-  padding: props.theme.space[2],
-  // The following values are taken from theme, but copy&pasted for ease of use.
-  // Same as AutosuggestField
-  boxShadow: `0 0 0 1px hsl(210, 24%, 87%), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)`,
+  'minWidth': '100px',
+  'backgroundColor': props.theme.colors.white,
+  'borderRadius': props.theme.radii[2],
+  'padding': props.theme.space[2],
+  '&::after': {
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    zIndex: '-1',
+    borderRadius: props.theme.radii[2],
+    // The following values are taken from theme, but copy&pasted for ease of use.
+    // Same as AutosuggestField
+    boxShadow: `0 0 0 1px hsl(210, 24%, 87%), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)`,
+  },
 }))
 
 const useItemStyles = props => ({


### PR DESCRIPTION
The `DropdownMenu.Content` component had a `box-shadow` applied.
However, the shadow was removed by a rule in our global CSS reset:

```
*:focus:not(:focus-visible) {
  outline: none !important;
  box-shadow: none !important;
  border: none !important;
}
```

This commit fixes that by using a pseudo-element for the shadow instead,
because pseudo-elements aren't targeted by the global rule.

Since this rule has a purpose[0], we don't want to get rid of it just
yet. If it continues to trouble us, we might reconsider removing it.
Removing it would require us to change *a lot* of our focus styles,
though, so I'm really hesitant to do it.

[0] https://www.tpgi.com/focus-visible-and-backwards-compatibility/
