### PR TITLE
Quickfix: update the lock file and add a changeset for it

### DIFF
--- a/.changeset/wild-walls-peel.md
+++ b/.changeset/wild-walls-peel.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Update the package lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualifyze/design-system",
-  "version": "1.5.1",
+  "version": "1.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualifyze/design-system",
-      "version": "1.5.1",
+      "version": "1.6.5",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": "10.1.1",


### PR DESCRIPTION
# What❓

We are trying to use the new version of the design system in legacy. for some reason we cannot figure out. The new code changes are not applying in legacy. but only in legacy. It could be the package lock of the DS 🤷  to be honest at this stage we are just clutching at straws to try figure it out.


