### PR TITLE
Quickfix: Allow type date for `TextField`

### DIFF
--- a/.changeset/healthy-chefs-end.md
+++ b/.changeset/healthy-chefs-end.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Quickfix: Allow type date for `TextField`

--- a/src/components/TextField/index.jsx
+++ b/src/components/TextField/index.jsx
@@ -112,6 +112,7 @@ TextField.propTypes = {
     'tel',
     'time',
     'url',
+    'date',
   ]),
   placeholder: PropTypes.string,
   message: PropTypes.string,


### PR DESCRIPTION
# What❓

This allows the type property of the TextField component to accept "date", so the field can be used as a date input field

# Why 💁‍♀️

We are already using this field as an input for dates on the audit date selection. This currently produces a warning in the console.
