### PR TITLE
Stop using negative top margin on Stack

### DIFF
--- a/src/components/Stack/index.jsx
+++ b/src/components/Stack/index.jsx
@@ -7,7 +7,6 @@ import flattenChildren from 'react-keyed-flatten-children'
 
 import { propType } from '../../util/style'
 import Box from '../Box'
-import useNegativeValue from '../private/hooks/useNegativeValue'
 
 const useStackItem = ({ align, space }) => ({
   pt: space,
@@ -29,11 +28,17 @@ const Stack = ({ as, space, children, align }) => {
   // when the stack should be a list we need to render `<li>`s
   const isList = as === 'ol' || as === 'ul'
   const stackItemComponent = isList ? 'li' : 'div'
-  const stackItemProps = useStackItem({ space, align })
+  // We don't expect the first child component to be spaced so it doesn't need top spacing
+  // We had previously tried negative margin top values on the top Box but leads
+  // to the component overlapping with other components
+  const firstStackItemProps = useStackItem({ space: 0, align })
+  const restStackItemProps = useStackItem({ space, align })
 
   return (
-    <Box as={as} mt={useNegativeValue(space)}>
-      {Children.map(stackItems, child => {
+    <Box as={as}>
+      {Children.map(stackItems, (child, index) => {
+        const stackItemProps =
+          index === 0 ? firstStackItemProps : restStackItemProps
         return (
           <Box as={stackItemComponent} {...stackItemProps}>
             {child}

--- a/src/components/Stack/index.stories.jsx
+++ b/src/components/Stack/index.stories.jsx
@@ -1,7 +1,11 @@
 import React from 'react'
+import { select } from '@storybook/addon-knobs'
 
 import Heading from '../Heading'
 import Text from '../Text'
+import Box from '../Box'
+import Button from '../Button'
+import Inline from '../Inline'
 
 import Stack from './index'
 
@@ -18,4 +22,25 @@ export const Default = () => {
 }
 Default.story = {
   name: 'default',
+}
+
+export const ContentOnTop = () => {
+  const availableSpaces = [1, 2, 3, 4, 5]
+  const space = select('Space', availableSpaces, 1)
+
+  return (
+    <Box>
+      <Inline>
+        <Button>Click me</Button>
+      </Inline>
+      <Stack space={space} align="left">
+        <Heading>Try using a high space value</Heading>
+        <Text>Like 5</Text>
+        <Text>You should be able to click on the button</Text>
+      </Stack>
+    </Box>
+  )
+}
+ContentOnTop.story = {
+  name: 'with clickable content on top',
 }


### PR DESCRIPTION
# What❓

If space prop is 5, Stack component will overlap top component and won't allow to click it. 
Removed the margin top negative space and stop providing space to the first child stack Item.
This change should be backwards compatible since we don't change what the user expects or the API of the Stack component.

# Why 💁‍♀️
This negative margin generated layout issues and we have to adjust for the spacing of the first stack item.

# How to test ✅
1. Start Storybook
2. Go into Stack stories, look for 'with clickable content on top'
3. Pick any values for 'space' under 'Knobs' tab
4. Try to click the Button component
