### PR TITLE
Add a new side bar component in the design system as a type of modal

### DIFF
--- a/.changeset/tiny-ties-explain.md
+++ b/.changeset/tiny-ties-explain.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': minor
+---
+
+Add a new type of modal, the side bar

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualifyze/design-system",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualifyze/design-system",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": "10.1.1",

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -40,6 +40,18 @@ const DialogContent = styled(BaseDialogContent, {
   // in the DOM since its not supported
   shouldForwardProp: prop => prop !== 'maxWidth',
 })(props => {
+  const sideBarStyles = props.asSidebar
+    ? {
+        right: 0,
+        bottom: 0,
+        top: 0,
+        position: 'fixed',
+        overflowY: 'scroll',
+        height: '100%',
+        margin: '0 !important',
+        borderRadius: '0 !important',
+      }
+    : {}
   return {
     '&[data-reach-dialog-content]': {
       width: `100%`,
@@ -48,6 +60,7 @@ const DialogContent = styled(BaseDialogContent, {
       background: `white`,
       position: `relative`,
       marginTop: props.theme.space[6],
+      ...sideBarStyles,
       [`@media (min-width: ${props.theme.breakpoints.small})`]: {
         borderRadius: props.theme.radii[2],
         maxWidth: props.theme.sizes[props.maxWidth],
@@ -69,7 +82,7 @@ const DialogOverlay = styled(BaseDialogOverlay)(() => {
 // this is the base modal it is very basic right now we use the overlay and the content
 // as we add custom styling to both of these components. if the custom styling is
 // removed we can just use the Dialog component that comes from the plugin
-const Modal = ({ isOpen, onDismiss, maxWidth, children }) => {
+const Modal = ({ isOpen, onDismiss, maxWidth, children, asSidebar }) => {
   const headingId = useId()
 
   return (
@@ -85,7 +98,11 @@ const Modal = ({ isOpen, onDismiss, maxWidth, children }) => {
           px: [0, 3],
         }}
       >
-        <DialogContent maxWidth={maxWidth} aria-labelledby={headingId}>
+        <DialogContent
+          asSidebar={asSidebar}
+          maxWidth={maxWidth}
+          aria-labelledby={headingId}
+        >
           <Box
             aria-hidden
             as="button"
@@ -130,12 +147,14 @@ Modal.Body = Body
 Modal.defaultProps = {
   onDismiss: null,
   maxWidth: 'medium',
+  asSidebar: false,
 }
 
 Modal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onDismiss: PropTypes.func,
   children: PropTypes.node.isRequired,
+  asSidebar: PropTypes.bool,
   maxWidth: PropTypes.oneOf(['narrow', 'medium', 'wide', 'page']),
 }
 

--- a/src/components/Modal/index.stories.jsx
+++ b/src/components/Modal/index.stories.jsx
@@ -227,3 +227,77 @@ export const WithSelect = () => {
 WithSelect.story = {
   name: 'with a select input',
 }
+
+export const AsSidebar = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <Box>
+        <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+      </Box>
+      <Modal isOpen={isOpen} onDismiss={() => setIsOpen(false)} asSidebar>
+        <Modal.Heading>This is an item which is a side bar</Modal.Heading>
+        <Modal.Body>
+          <Stack space={3}>
+            <Text>
+              Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi
+              welsh onion daikon amaranth tatsoi tomatillo melon azuki bean
+              garlic.
+            </Text>
+            <Text>
+              Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot
+              courgette tatsoi pea sprouts fava bean collard greens dandelion
+              okra wakame tomato. Dandelion cucumber earthnut pea peanut soko
+              zucchini.
+            </Text>
+            <Text>
+              Turnip greens yarrow ricebean rutabaga endive cauliflower sea
+              lettuce kohlrabi amaranth water spinach avocado daikon napa
+              cabbage asparagus winter purslane kale. Celery potato scallion
+              desert raisin horseradish spinach carrot soko. Lotus root water
+              spinach fennel kombu maize bamboo shoot green bean swiss chard
+              seakale pumpkin onion chickpea gram corn pea. Brussels sprout
+              coriander water chestnut gourd swiss chard wakame kohlrabi
+              beetroot carrot watercress. Corn amaranth salsify bunya nuts nori
+              azuki bean chickweed potato bell pepper artichoke.
+            </Text>
+            <Text>
+              Nori grape silver beet broccoli kombu beet greens fava bean potato
+              quandong celery. Bunya nuts black-eyed pea prairie turnip leek
+              lentil turnip greens parsnip. Sea lettuce lettuce water chestnut
+              eggplant winter purslane fennel azuki bean earthnut pea sierra
+              leone bologi leek soko chicory celtuce parsley jï¿½cama salsify.
+            </Text>
+            <Text>
+              Celery quandong swiss chard chicory earthnut pea potato. Salsify
+              taro catsear garlic gram celery bitterleaf wattle seed collard
+              greens nori. Grape wattle seed kombu beetroot horseradish carrot
+              squash brussels sprout chard.
+            </Text>
+            <Text>
+              Pea horseradish azuki bean lettuce avocado asparagus okra.
+              Kohlrabi radish okra azuki bean corn fava bean mustard tigernut
+              jï¿½cama green bean celtuce collard greens avocado quandong fennel
+              gumbo black-eyed pea. Grape silver beet watercress potato tigernut
+              corn groundnut. Chickweed okra pea winter purslane coriander
+              yarrow sweet pepper radish garlic brussels sprout groundnut summer
+              purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo
+              kakadu plum komatsuna black-eyed pea green bean zucchini gourd
+              winter purslane silver beet rock melon radish asparagus spinach.
+            </Text>
+          </Stack>
+        </Modal.Body>
+        <Modal.Actions>
+          <Button onClick={() => setIsOpen(false)}>Do something fun</Button>
+          <Button variant="secondary" onClick={() => setIsOpen(false)}>
+            Close
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    </>
+  )
+}
+AsSidebar.story = {
+  name: 'As a side bar',
+}


### PR DESCRIPTION
# What❓

Here we have a new component type on modal, it is the sidebar!

this, right now is simply a modal window with some styles that make it add like a side bar

# Why 💁‍♀️

There are cases and this is happening more and more where we need to do things that may trigger a modal within a context of something that should not be on an entirely new page.

we have a story which is an example of this, you need to share access to a request and see a list of people with access. each thing on that list may trigger a modal for example "remove user" from access.

in theory this should be a page but in practice it is much nicer for the user to have a side bar that is contextual to the page you are working on. In our case the request. it makes the whole action feel quicker and have a nicer UX.


this is how it looks (sorry for my small mac screen):

<img width="1265" alt="Screenshot 2022-02-10 at 17 44 33" src="https://user-images.githubusercontent.com/1426390/153454925-6a605214-f65b-4d03-8995-b370fef7b80e.png">


# How to test ✅

Check the storybook preview there is a new story with a type of modal, that type of modal is now side bar. you can use it with a new boolean "asSidebar" on the modal. 

check it out and make sure it works in the way we expect. in reality it is just some simple style changes to the modal

# What was tested / affected 📝

It will not effect any existing modals as this prop is by default false

