### PR TITLE
Add a material style progress bar under buttons on loading

### DIFF
--- a/.changeset/nervous-meals-smile.md
+++ b/.changeset/nervous-meals-smile.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': minor
+---
+
+Add a new style of laoding for buttons

--- a/src/components/Button/LoadingBar.jsx
+++ b/src/components/Button/LoadingBar.jsx
@@ -1,0 +1,162 @@
+// lovingly stolen from https://codepen.io/sirJiggles/pen/oNowExg
+import React from 'react'
+
+import { styled } from '../../util/style'
+import Box from '../Box'
+
+const LoadingMarkup = () => {
+  const barStyles = {
+    position: 'absolute',
+    height: '4px',
+    bg: 'rgba(255,255,255,0.6)',
+    transition: 'transform .2s linear',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: '100%',
+  }
+  return (
+    <Box
+      as="span"
+      sx={{
+        bg: 'rgba(255,255,255,0.2)',
+        height: '4px',
+        bottom: 0,
+        left: 0,
+        position: 'absolute',
+        width: '100%',
+        margin: '0 auto',
+        overflow: 'hidden',
+        animation: 'start .3s ease-in',
+        display: 'inline-block',
+      }}
+    >
+      <Box
+        as="span"
+        sx={{
+          ...barStyles,
+          animation: 'progressLinearMovement 2.5s infinite',
+          animationDelay: 0,
+        }}
+      />
+      <Box
+        as="span"
+        sx={{
+          ...barStyles,
+          left: '-100%',
+          animation: 'progressLinearMovement 2.5s infinite',
+          animationDelay: '.7s',
+        }}
+      />
+    </Box>
+  )
+}
+
+export const LoadingBar = styled(LoadingMarkup)`
+
+  @keyframes growBar1 {
+    0% {
+      animation-timing-function: linear;
+      transform: scaleX(.1);
+    }
+    36% {
+      animation-timing-function: cubic-bezier(.33473,.12482,.78584,1);
+      transform: scaleX(.1);
+    }
+    69% {
+      animation-timing-function: cubic-bezier(.22573,0,.23365,1.37098);
+      transform: scaleX(.83);
+    }
+    100% {
+      transform: scaleX(.1);
+    }
+  }
+
+  @keyframes moveBar1 {
+    0% {
+      left: -105.16667%
+      animation-timing-function: linear
+    }
+    20% {
+      left: -105.16667%;
+      animation-timing-function: cubic-bezier(.5,0,.70173,.49582);
+    }
+    69% {
+      left: 21.5%;
+      animation-timing-function: cubic-bezier(.30244,.38135,.55,.95635);
+    }
+    100% {
+      left: 95.44444%;
+    }
+  }
+
+  @keyframes growBar2 {
+        0% {
+            animation-timing-function: cubic-bezier(.20503,.05705,.57661,.45397);
+            transform: scaleX(.1);
+        }
+        19% {
+            animation-timing-function: cubic-bezier(.15231,.19643,.64837,1.00432);
+            transform: scaleX(.57);
+        }
+        44% {
+            animation-timing-function: cubic-bezier(.25776,-.00316,.21176,1.38179);
+            transform: scaleX(.91);
+        }
+        100% {
+            transform: scaleX(.1);
+        }
+  }
+
+    @keyframes moveBar2 {
+        0% {
+            left: -54.88889%;
+            animation-timing-function: cubic-bezier(.15,0,.51506,.40968);
+        }
+        25% {
+            left: -17.25%;
+            animation-timing-function: cubic-bezier(.31033,.28406,.8,.73372);
+        }
+        48% {
+            left: 29.5%;
+            animation-timing-function: cubic-bezier(.4,.62703,.6,.90203);
+        }
+        100% {
+            left: 117.38889%;
+        }
+    }
+
+    @keyframes start {
+        from {
+            max-height: 0;
+            opacity: 0;
+        }
+        to {
+            max-height: 20px;
+            opacity: 1;
+        }
+    }
+
+    @keyframes end {
+        from {
+            max-height: 0;
+            opacity: 0;
+        }
+        to {
+            max-height: 2px;
+            opacity: 1;
+        }
+    }
+
+    @keyframes progressLinearMovement {
+        0% {
+            left: -100%;
+        }
+        50% {
+            left: 100%;
+        }
+        100% {
+            left: 100%;
+        }
+    }
+`

--- a/src/components/Button/LoadingBar.jsx
+++ b/src/components/Button/LoadingBar.jsx
@@ -53,37 +53,36 @@ const LoadingMarkup = () => {
 }
 
 export const LoadingBar = styled(LoadingMarkup)`
-
   @keyframes growBar1 {
     0% {
       animation-timing-function: linear;
-      transform: scaleX(.1);
+      transform: scaleX(0.1);
     }
     36% {
-      animation-timing-function: cubic-bezier(.33473,.12482,.78584,1);
-      transform: scaleX(.1);
+      animation-timing-function: cubic-bezier(0.33473, 0.12482, 0.78584, 1);
+      transform: scaleX(0.1);
     }
     69% {
-      animation-timing-function: cubic-bezier(.22573,0,.23365,1.37098);
-      transform: scaleX(.83);
+      animation-timing-function: cubic-bezier(0.22573, 0, 0.23365, 1.37098);
+      transform: scaleX(0.83);
     }
     100% {
-      transform: scaleX(.1);
+      transform: scaleX(0.1);
     }
   }
 
   @keyframes moveBar1 {
     0% {
-      left: -105.16667%
-      animation-timing-function: linear
+      left: -105.16667%;
+      animation-timing-function: linear;
     }
     20% {
       left: -105.16667%;
-      animation-timing-function: cubic-bezier(.5,0,.70173,.49582);
+      animation-timing-function: cubic-bezier(0.5, 0, 0.70173, 0.49582);
     }
     69% {
       left: 21.5%;
-      animation-timing-function: cubic-bezier(.30244,.38135,.55,.95635);
+      animation-timing-function: cubic-bezier(0.30244, 0.38135, 0.55, 0.95635);
     }
     100% {
       left: 95.44444%;
@@ -91,72 +90,87 @@ export const LoadingBar = styled(LoadingMarkup)`
   }
 
   @keyframes growBar2 {
-        0% {
-            animation-timing-function: cubic-bezier(.20503,.05705,.57661,.45397);
-            transform: scaleX(.1);
-        }
-        19% {
-            animation-timing-function: cubic-bezier(.15231,.19643,.64837,1.00432);
-            transform: scaleX(.57);
-        }
-        44% {
-            animation-timing-function: cubic-bezier(.25776,-.00316,.21176,1.38179);
-            transform: scaleX(.91);
-        }
-        100% {
-            transform: scaleX(.1);
-        }
+    0% {
+      animation-timing-function: cubic-bezier(
+        0.20503,
+        0.05705,
+        0.57661,
+        0.45397
+      );
+      transform: scaleX(0.1);
+    }
+    19% {
+      animation-timing-function: cubic-bezier(
+        0.15231,
+        0.19643,
+        0.64837,
+        1.00432
+      );
+      transform: scaleX(0.57);
+    }
+    44% {
+      animation-timing-function: cubic-bezier(
+        0.25776,
+        -0.00316,
+        0.21176,
+        1.38179
+      );
+      transform: scaleX(0.91);
+    }
+    100% {
+      transform: scaleX(0.1);
+    }
   }
 
-    @keyframes moveBar2 {
-        0% {
-            left: -54.88889%;
-            animation-timing-function: cubic-bezier(.15,0,.51506,.40968);
-        }
-        25% {
-            left: -17.25%;
-            animation-timing-function: cubic-bezier(.31033,.28406,.8,.73372);
-        }
-        48% {
-            left: 29.5%;
-            animation-timing-function: cubic-bezier(.4,.62703,.6,.90203);
-        }
-        100% {
-            left: 117.38889%;
-        }
+  @keyframes moveBar2 {
+    0% {
+      left: -54.88889%;
+      animation-timing-function: cubic-bezier(0.15, 0, 0.51506, 0.40968);
     }
+    25% {
+      left: -17.25%;
+      animation-timing-function: cubic-bezier(0.31033, 0.28406, 0.8, 0.73372);
+    }
+    48% {
+      left: 29.5%;
+      animation-timing-function: cubic-bezier(0.4, 0.62703, 0.6, 0.90203);
+    }
+    100% {
+      left: 117.38889%;
+    }
+  }
 
-    @keyframes start {
-        from {
-            max-height: 0;
-            opacity: 0;
-        }
-        to {
-            max-height: 20px;
-            opacity: 1;
-        }
+  @keyframes start {
+    from {
+      max-height: 0;
+      opacity: 0;
     }
+    to {
+      max-height: 20px;
+      opacity: 1;
+    }
+  }
 
-    @keyframes end {
-        from {
-            max-height: 0;
-            opacity: 0;
-        }
-        to {
-            max-height: 2px;
-            opacity: 1;
-        }
+  @keyframes end {
+    from {
+      max-height: 0;
+      opacity: 0;
     }
+    to {
+      max-height: 2px;
+      opacity: 1;
+    }
+  }
 
-    @keyframes progressLinearMovement {
-        0% {
-            left: -100%;
-        }
-        50% {
-            left: 100%;
-        }
-        100% {
-            left: 100%;
-        }
+  @keyframes progressLinearMovement {
+    0% {
+      left: -100%;
     }
+    50% {
+      left: 100%;
+    }
+    100% {
+      left: 100%;
+    }
+  }
 `

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types'
 import { styled, variant } from '../../util/style'
 import Box from '../Box'
 
+import { LoadingBar } from './LoadingBar'
+
 const Base = styled('button')(
   props => ({
     'revert': 'all',
@@ -73,42 +75,6 @@ const Base = styled('button')(
   })
 )
 
-export const Loader = styled.span`
-  display: 'inline-block';
-
-  & > span {
-    width: 0.15em;
-    height: 0.15em;
-    background-color: currentColor;
-    border-radius: 100%;
-    display: inline-block;
-    animation: loading-animation 1000ms infinite ease-in-out both;
-  }
-
-  & > span:nth-of-type(1) {
-    margin-left: 0.25em;
-    margin-right: 0.15em;
-    animation-delay: -320ms;
-  }
-
-  & > span:nth-of-type(2) {
-    margin-right: 0.15em;
-    animation-delay: -160ms;
-  }
-
-  @keyframes loading-animation {
-    0%,
-    80%,
-    100% {
-      transform: scale(0);
-    }
-
-    40% {
-      transform: scale(1);
-    }
-  }
-`
-
 const Button = forwardRef(
   ({ children, icon, isLoading, onClick, ...props }, ref) => {
     return (
@@ -119,13 +85,7 @@ const Button = forwardRef(
           </Box>
         ) : null}
         {children}
-        {isLoading ? (
-          <Loader aria-hidden>
-            <span />
-            <span />
-            <span />
-          </Loader>
-        ) : null}
+        {isLoading ? <LoadingBar aria-hidden /> : null}
       </Base>
     )
   }

--- a/src/components/TextLink/index.jsx
+++ b/src/components/TextLink/index.jsx
@@ -5,7 +5,43 @@ import PropTypes from 'prop-types'
 import { styled, createShouldForwardProp, props, sx } from '../../util/style'
 import ActionsContext from '../Actions/ActionsContext'
 import Box from '../Box'
-import { Loader } from '../Button'
+
+// this used to be on the button but is now only here
+const Loader = styled.span`
+  display: 'inline-block';
+
+  & > span {
+    width: 0.15em;
+    height: 0.15em;
+    background-color: currentColor;
+    border-radius: 100%;
+    display: inline-block;
+    animation: loading-animation 1000ms infinite ease-in-out both;
+  }
+
+  & > span:nth-of-type(1) {
+    margin-left: 0.25em;
+    margin-right: 0.15em;
+    animation-delay: -320ms;
+  }
+
+  & > span:nth-of-type(2) {
+    margin-right: 0.15em;
+    animation-delay: -160ms;
+  }
+
+  @keyframes loading-animation {
+    0%,
+    80%,
+    100% {
+      transform: scale(0);
+    }
+
+    40% {
+      transform: scale(1);
+    }
+  }
+`
 
 const shouldForwardProp = createShouldForwardProp([
   ...props,


### PR DESCRIPTION
# What❓

Here I am just playing with the idea of having a different loading style on buttons, one that does not change the width of the button and potentially break layout just for fun after a chat with @pablosci 


# How to test ✅

I made it use white with opacity so it would work on all buttons and still look nice, it looks like this in the DS you can play with the loading button in story book and click on it to see it in action


https://user-images.githubusercontent.com/1426390/153674819-2c73eab1-58b4-4fdd-814d-498bd7be3acf.mov

I had to keep the old loader for text links with loading styles as they would look real bad with a loader under them like this. so I moved the loader that was in the button to text link and that still looks like this when loading.

<img width="220" alt="Screenshot 2022-02-11 at 22 44 32" src="https://user-images.githubusercontent.com/1426390/153674881-70927273-3de2-4ed3-9db7-e7f1a2538899.png">

so no change there