### PR TITLE
Fix negative margins leaking into/overlapping with adjacent components

### DIFF
--- a/.changeset/thin-avocados-double.md
+++ b/.changeset/thin-avocados-double.md
@@ -1,0 +1,9 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Fix CSS stacking context for several layout components
+
+The following components were "leaking" (layout-wise speaking) into adjacent components. We use negative margins for all of them, which resulted in adjacent interactive components (e.g., buttons) not being clickable because these components were overlapping with the buttons. This release fixes that by making sure all layout components use `position: static` to avoid creating a new CSS stacking context for them.
+
+The affected components are: `Stack`, `Inline`, `Column(s)`, and `Tiles`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualifyze/design-system",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualifyze/design-system",
-      "version": "1.6.7",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": "10.1.1",

--- a/src/components/Column/index.jsx
+++ b/src/components/Column/index.jsx
@@ -22,6 +22,7 @@ const Column = ({ width, children }) => {
         pl,
         width: resolveWidth[width] ?? width ?? defaultWidth,
         flexShrink: preventBreak ? 0 : null,
+        position: 'static',
       }}
     >
       {children}

--- a/src/components/Column/index.stories.jsx
+++ b/src/components/Column/index.stories.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { text, array, select } from '@storybook/addon-knobs'
+import { text, select } from '@storybook/addon-knobs'
 
+import Box from '../Box'
+import Button from '../Button'
 import Columns from '../Columns'
 import Placeholder from '../private/Placeholder'
 
@@ -8,8 +10,11 @@ import Column from './index'
 
 export default { title: 'Column', component: Column }
 
+// All possible values for `space` according to our theme
+const ALL_SPACES = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
 export const Default = () => {
-  const space = array('Space', [1, 3, 5])
+  const space = select('Space', ALL_SPACES, 5)
   const firstColWith = text('first col width', '20%')
   const secondColWidth = text('second col width', '30%')
   const thirdColWidth = text('third col width', '50%')
@@ -69,4 +74,33 @@ export const AutoWidth = () => (
 )
 AutoWidth.story = {
   name: 'automatic width',
+}
+
+export const Adjacent = () => {
+  const space = select('Space', ALL_SPACES, 5)
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <Box>
+        <Button>Am I clickable?</Button>
+      </Box>
+      <Columns space={space}>
+        <Column>
+          <Placeholder height={50} width="100%" label="hello there" />
+        </Column>
+        <Column>
+          <Placeholder height={50} width="100%" label="hello there" />
+        </Column>
+        <Column>
+          <Placeholder height={50} width="100%" label="hello there" />
+        </Column>
+        <Column>
+          <Placeholder height={50} width="100%" label="hello there" />
+        </Column>
+      </Columns>
+    </Box>
+  )
+}
+Adjacent.story = {
+  name: 'with adjacent interactive elements',
 }

--- a/src/components/Columns/index.jsx
+++ b/src/components/Columns/index.jsx
@@ -44,8 +44,11 @@ const Columns = ({ children, collapseBelow, space, alignY, align }) => {
       {...useFlexAlignment(align, alignY, collapseBelow)}
       flexDirection={useFlexDirection(collapseBelow)}
       flexWrap={useFlexWrap(collapseBelow)}
-      ml={useNegativeValue(space)}
-      mt={useNegativeValue(space)}
+      sx={{
+        position: 'static',
+        mt: useNegativeValue(space),
+        ml: useNegativeValue(space),
+      }}
     >
       <ColumnsContext.Provider
         value={{

--- a/src/components/Inline/index.jsx
+++ b/src/components/Inline/index.jsx
@@ -10,6 +10,7 @@ import flattenChildren from 'react-keyed-flatten-children'
 import { propType } from '../../util/style'
 import Box from '../Box'
 import Flex from '../Flex'
+import useNegativeValue from '../private/hooks/useNegativeValue'
 
 import useFlexDirection from './useFlexDirection'
 import useAlignment from './useAlignment'
@@ -18,18 +19,32 @@ const Inline = ({ space, collapseBelow, alignY, children }) => {
   const inlineItems = flattenChildren(children)
 
   return (
-    <Box mt={-space}>
+    <Box
+      sx={{
+        'position': 'static',
+        '&::before': {
+          content: '""',
+          display: 'table',
+          mt: useNegativeValue(space),
+        },
+      }}
+    >
       <Flex
-        ml={-space}
         flexWrap="wrap"
         flexDirection={useFlexDirection(collapseBelow)}
         {...useAlignment(alignY)}
+        sx={{
+          'position': 'static',
+          '&::before': {
+            content: '""',
+            display: 'table',
+            ml: useNegativeValue(space),
+          },
+        }}
       >
         {Children.map(inlineItems, child => {
           return (
-            <Box pl={space} pt={space}>
-              {child}
-            </Box>
+            <Box sx={{ pl: space, pt: space, position: 'static' }}>{child}</Box>
           )
         })}
       </Flex>

--- a/src/components/Inline/index.stories.jsx
+++ b/src/components/Inline/index.stories.jsx
@@ -1,15 +1,23 @@
+/* eslint-disable no-alert */
 import React from 'react'
 import { select } from '@storybook/addon-knobs'
 
+import Box from '../Box'
+import Button from '../Button'
 import Placeholder from '../private/Placeholder'
 
 import Inline from './index'
 
+// All possible values for `space` according to our theme
+const ALL_SPACES = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+
 export default { title: 'Inline', component: Inline }
 
 export const Default = () => {
+  const space = select('Space', ALL_SPACES, 3)
+
   return (
-    <Inline space={3}>
+    <Inline space={space}>
       <Placeholder width={20} height={48} />
       <Placeholder width={80} height={48} />
       <Placeholder width={40} height={48} />
@@ -35,9 +43,10 @@ export const Collapsible = () => {
     ['mobile', 'tablet', 'desktop'],
     'tablet'
   )
+  const space = select('Space', ALL_SPACES, 3)
 
   return (
-    <Inline space={3} collapseBelow={collapseBelow}>
+    <Inline space={space} collapseBelow={collapseBelow}>
       <Placeholder width={48} height={48} />
       <Placeholder width={48} height={48} />
       <Placeholder width={48} height={48} />
@@ -53,9 +62,10 @@ Collapsible.story = {
 
 export const AlignY = () => {
   const alignY = select('alignY', ['top', 'center', 'bottom'], 'center')
+  const space = select('Space', ALL_SPACES, 3)
 
   return (
-    <Inline space={3} alignY={alignY}>
+    <Inline space={space} alignY={alignY}>
       <Placeholder width={32} height={32} />
       <Placeholder width={32} height={32} />
       <Placeholder width={32} height={32} />
@@ -71,4 +81,24 @@ export const AlignY = () => {
 }
 AlignY.story = {
   name: 'vertically aligned',
+}
+
+export const Adjacent = () => {
+  const space = select('Space', ALL_SPACES, 5)
+
+  return (
+    <Box css={{ display: 'flex', flexDirection: 'row' }}>
+      <Inline>
+        <Button onClick={() => alert('Yes i am!')}>Am I clickable?</Button>
+      </Inline>
+      <Inline space={space}>
+        <Placeholder width={50} height={50} />
+        <Placeholder width={50} height={50} />
+        <Placeholder width={50} height={50} />
+      </Inline>
+    </Box>
+  )
+}
+Adjacent.story = {
+  name: 'with adjacent interactive elements',
 }

--- a/src/components/Stack/index.jsx
+++ b/src/components/Stack/index.jsx
@@ -32,10 +32,24 @@ const Stack = ({ as, space, children, align }) => {
   const stackItemProps = useStackItem({ space, align })
 
   return (
-    <Box as={as} mt={useNegativeValue(space)}>
+    <Box
+      as={as}
+      sx={{
+        'position': 'static',
+        '&::before': {
+          content: '""',
+          display: 'table',
+          mt: useNegativeValue(space),
+        },
+      }}
+    >
       {Children.map(stackItems, child => {
         return (
-          <Box as={stackItemComponent} {...stackItemProps}>
+          <Box
+            as={stackItemComponent}
+            {...stackItemProps}
+            sx={{ position: 'static' }}
+          >
             {child}
           </Box>
         )

--- a/src/components/Stack/index.stories.jsx
+++ b/src/components/Stack/index.stories.jsx
@@ -1,21 +1,51 @@
+/* eslint-disable no-alert */
 import React from 'react'
+import { select } from '@storybook/addon-knobs'
 
-import Heading from '../Heading'
-import Text from '../Text'
+import Box from '../Box'
+import Button from '../Button'
+import Inline from '../Inline'
+import Placeholder from '../private/Placeholder'
 
 import Stack from './index'
+
+// All possible values for `space` according to our theme
+const ALL_SPACES = [0, 1, 2, 3, 4, 5, 6, 7, 8]
 
 export default { title: 'Stack', component: Stack }
 
 export const Default = () => {
+  const space = select('Space', ALL_SPACES, 3)
+
   return (
-    <Stack space={4} align="left">
-      <Heading>Heading goes here</Heading>
-      <Text>Text goes here</Text>
-      <Text>And even more goes here</Text>
+    <Stack space={space}>
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
     </Stack>
   )
 }
 Default.story = {
   name: 'default',
+}
+
+export const Adjacent = () => {
+  const space = select('Space', ALL_SPACES, 3)
+
+  return (
+    <Box>
+      <Inline>
+        <Button onClick={() => alert('I am!')}>Am I clickable?</Button>
+      </Inline>
+      <Stack space={space}>
+        <Placeholder height={50} width="100%" />
+        <Placeholder height={50} width="100%" />
+        <Placeholder height={50} width="100%" />
+      </Stack>
+    </Box>
+  )
+}
+Adjacent.story = {
+  name: 'with adjacent interactive elements',
 }

--- a/src/components/Tiles/index.jsx
+++ b/src/components/Tiles/index.jsx
@@ -14,14 +14,20 @@ import useAlignment from './useAlignment'
 const Tiles = ({ columns, as, space, align, children }) => (
   <Box
     as={as}
-    sx={{ display: 'block', width: '100%', mt: useNegativeValue(space) }}
+    sx={{
+      display: 'block',
+      width: '100%',
+      position: 'static',
+      mt: useNegativeValue(space),
+    }}
   >
     <Box
       sx={{
         display: 'flex',
         flexWrap: 'wrap',
-        ml: useNegativeValue(space),
         justifyContent: useAlignment(align),
+        position: 'static',
+        ml: useNegativeValue(space),
       }}
     >
       {Children.map(flattenChildren(children), child => (
@@ -29,6 +35,7 @@ const Tiles = ({ columns, as, space, align, children }) => (
           sx={{
             'minWidth': 0,
             'flex': useColumns(columns),
+            'position': 'static',
             '@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none)':
               {
                 // IE11 needs this overflow, although it doesn't change the layout.
@@ -40,6 +47,7 @@ const Tiles = ({ columns, as, space, align, children }) => (
           <Box
             sx={{
               height: '100%',
+              position: 'static',
               /* This needs to be a separate element to support IE11. */
               paddingTop: space,
               paddingLeft: space,

--- a/src/components/Tiles/index.stories.jsx
+++ b/src/components/Tiles/index.stories.jsx
@@ -1,16 +1,22 @@
+/* eslint-disable no-alert */
 import React from 'react'
-import { text, array } from '@storybook/addon-knobs'
+import { text, select } from '@storybook/addon-knobs'
 
 import Placeholder from '../private/Placeholder'
+import Box from '../Box'
+import Button from '../Button'
 
 import Tiles from './index'
+
+// All possible values for `space` according to our theme
+const ALL_SPACES = [0, 1, 2, 3, 4, 5, 6, 7, 8]
 
 export default { title: 'Tiles', component: Tiles }
 
 export const Default = () => {
   const as = text('as', 'div')
-  const columns = array('columns', [1, 2, 3])
-  const space = array('space', [1, 3, 5])
+  const columns = select('Columns', [1, 2, 3, 4], 3)
+  const space = select('Space', ALL_SPACES, 5)
 
   return (
     <Tiles columns={columns} as={as} space={space}>
@@ -28,4 +34,32 @@ export const Default = () => {
 }
 Default.story = {
   name: 'default',
+}
+
+export const Adjacent = () => {
+  const as = text('as', 'div')
+  const columns = select('Columns', [1, 2, 3, 4], 3)
+  const space = select('Space', ALL_SPACES, 5)
+
+  return (
+    <Box>
+      <Box>
+        <Button onClick={() => alert('Yes I am!')}>Am I clickable?</Button>
+      </Box>
+      <Tiles columns={columns} as={as} space={space}>
+        <Placeholder height={50} />
+        <Placeholder height={50} />
+        <Placeholder height={50} />
+        <Placeholder height={50} />
+        <Placeholder height={50} />
+        <Placeholder height={50} />
+        <Placeholder height={50} />
+        <Placeholder height={50} />
+        <Placeholder height={50} />
+      </Tiles>
+    </Box>
+  )
+}
+Adjacent.story = {
+  name: 'with adjacent interactive elements',
 }


### PR DESCRIPTION
# What❓

We have a tiny with our layout components†: They "leak" outside of themselves
because we're using negative margins. More specifically, if you place an
interactive component (e.g., a button) right adjacent, the components will
overlap the button and make it unclickable.

We need to make sure interactive elements adjacent to layout components†
remain clickable.

†The affected components are: `Stack`, `Inline`, `Column(s)`, and `Tiles`.

# Why does this happen?
We have a `position: relative;` on all our `Box` components, which means
they will implicitly create a new stacking context[0]. And we use these
`Box`es inside all of these layout components†.

[0] https://www.joshwcomeau.com/css/stacking-contexts/

# How to test ✅

I've added reproductions for all of the affected components named
"with adjacent interactive elements". The change can be tested by checking
whether the button in these stories is clickable, independent of the `space`
used.

Note: I have tried to add automated tests for this, but for some reason
these automated tests do not pick up on the CSS issues we fix here.
So I gave up and resorted to manually testing it inside stories.