### PR TITLE
VE-245 Add explanation and example about Stack component leaking

### DIFF
--- a/.changeset/four-dingos-live.md
+++ b/.changeset/four-dingos-live.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Add explanation and example about Stack component leaking

--- a/README.md
+++ b/README.md
@@ -34,3 +34,30 @@ This project includes several components that have to work even when they are la
 | Cookie Banner (in `website`) | 900       |
 | Notification                 | ???       |
 | Modal                        | 500       |
+
+## Limitations and known issues
+
+### Stack component with large `space` prop values
+
+Child components of `Stack` might "leak" into other components if values above 4 are given to it in the `space` prop, blocking interaction with other UI elements like buttons or text. 
+
+Workaround is to wrap the component that "leaks" and the one "leaked into" in `Box` or `Flex` components and provide `z-index` for both.
+
+```jsx
+import Box from "./index";
+
+<Box>
+  <Box sx={{zIndex: 2}}>
+    <Button> You can't click Me!</Button>
+  </Box>
+  <Box sx={{zIndex: 1}}>
+    <Stack space={5}>
+      <Button> Just a regular button</Button>
+    </Stack>
+  </Box>
+</Box>
+```
+You can find an example taken from the platform in the `Stack` stories in storybook under "leaking example".
+
+Fixing this requires a major version release because we still need to support [Internet Explorer](https://death-to-ie11.com/).
+

--- a/src/components/Stack/index.stories.jsx
+++ b/src/components/Stack/index.stories.jsx
@@ -1,11 +1,13 @@
 /* eslint-disable no-alert */
 import React from 'react'
-import { select } from '@storybook/addon-knobs'
+import { select, boolean } from '@storybook/addon-knobs'
 
 import Box from '../Box'
 import Button from '../Button'
 import Inline from '../Inline'
 import Placeholder from '../private/Placeholder'
+import Flex from '../Flex'
+import Text from '../Text'
 
 import Stack from './index'
 
@@ -48,4 +50,40 @@ export const Adjacent = () => {
 }
 Adjacent.story = {
   name: 'with adjacent interactive elements',
+}
+
+export const LeakingExample = () => {
+  const space = select('Space', ALL_SPACES, 6)
+  const withIndex = boolean('Using z-index', true)
+
+  return (
+    <Box sx={{ border: 'solid 3px black' }}>
+      <Text>Check the README for an explanation</Text>
+      <Flex
+        sx={{
+          zIndex: withIndex ? '2' : null,
+        }}
+      >
+        <Inline>
+          <Button onClick={() => alert('Yes, I am!')}>
+            But am I clickable? Try me with and without z-index and a space
+            value above 4
+          </Button>
+        </Inline>
+      </Flex>
+      <Box sx={{ zIndex: withIndex ? '1' : null, border: 'solid 3px red' }}>
+        <Stack space={space}>
+          <Inline>
+            <Button onClick={() => alert('I am!')}>Am I clickable?</Button>
+          </Inline>
+          <Placeholder height={50} width="100%" />
+          <Placeholder height={50} width="100%" />
+          <Placeholder height={50} width="100%" />
+        </Stack>
+      </Box>
+    </Box>
+  )
+}
+LeakingExample.story = {
+  name: 'leaking example',
 }


### PR DESCRIPTION
# What❓

Added explanation of known issue of `Stack` component into README and an example.

# Why 💁‍♀️

It's not a recurring issue and fixing it requires us to introduce a major version or drop support for Internet Explorer, so not possible to tackle now. The least we can do is just to make it easier for future users of the DS to find it. 

# How to test ✅

1. Go to storybook
2. Look for `leaking example` under `Stack`
3. Try the example with multiple `space` values and turning on/off the z index checkbox.

# What was tested / affected 📝
No one should be negatively affected and hopefully we can help future consumers of the Design System to deal with the issue.

# Related branches ↖️
#270 
