### PR TITLE
VE-235: Extend Tag component with optional Icon

### DIFF
--- a/.changeset/itchy-teachers-yawn.md
+++ b/.changeset/itchy-teachers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': minor
+---
+
+Extend Tag component with optional Icon and fix pointer if clickable

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qualifyze/design-system",
   "description": "Qualifyze Design System",
-  "version": "1.7.2",
+  "version": "1.8.2",
   "license": "MIT",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/Tag/index.jsx
+++ b/src/components/Tag/index.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types'
 
 import { styled } from '../../util/style'
 import Text from '../Text'
+import Box from '../Box'
 
 const Base = styled('span')(props => ({
   'position': 'relative',
   'paddingLeft': props.theme.space[2],
   'paddingRight': props.theme.space[2],
   'whiteSpace': 'nowrap',
+  'cursor': props.onClick ? 'pointer' : 'text',
   '& > span': {
     'color': props.theme.colors.grey[700],
     '&::after': {
@@ -34,11 +36,16 @@ const Base = styled('span')(props => ({
   },
 }))
 
-const Tag = forwardRef(({ children, as, onClick }, ref) => (
+const Tag = forwardRef(({ children, as, icon, onClick }, ref) => (
   <Base as={as} ref={ref} onClick={onClick}>
     <Text as="span" size="small" weight="medium">
       {children}
     </Text>
+    {icon ? (
+      <Box as="span" sx={{ pl: 2 }}>
+        {icon}
+      </Box>
+    ) : null}
   </Base>
 ))
 
@@ -47,6 +54,7 @@ Tag.displayName = 'Tag'
 Tag.defaultProps = {
   as: 'span',
   onClick: null,
+  icon: null,
 }
 
 Tag.propTypes = {
@@ -54,6 +62,7 @@ Tag.propTypes = {
   as: PropTypes.string,
   onClick: PropTypes.func,
   children: PropTypes.string.isRequired,
+  icon: PropTypes.node,
 }
 
 export default Tag

--- a/src/components/Tag/index.stories.jsx
+++ b/src/components/Tag/index.stories.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { array } from '@storybook/addon-knobs'
+import { array, text } from '@storybook/addon-knobs'
 
 import Inline from '../Inline'
 import Stack from '../Stack'
 import Text from '../Text'
+import Icon from '../Icon'
 
 import Tag from './index'
 
@@ -22,6 +23,7 @@ export const Default = () => {
         {MultipleExamples.map(content => (
           <Tag key={`${content}`}>{content}</Tag>
         ))}
+        <Tag onClick={() => {}}>Clickable Tag</Tag>
       </Inline>
       <Text>
         Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
@@ -39,4 +41,20 @@ export const Default = () => {
 }
 Default.story = {
   name: 'default',
+}
+
+export const WithIcon = () => {
+  const iconName = text('Icon', 'pencil')
+  const content = text('Text', 'Tag including an icon')
+
+  return (
+    <Stack space={4}>
+      <Inline space={1}>
+        <Tag icon={<Icon name={iconName} size="tiny" />}>{content}</Tag>
+      </Inline>
+    </Stack>
+  )
+}
+WithIcon.story = {
+  name: 'with Icon',
 }


### PR DESCRIPTION
# What❓

This adds an optional Icon to the `Tag` component. In addition, the `Tag` component now shows the right cursor when an onClick handler has been provided
