### PR TITLE
Quickfix: Make close button on Modal always actionable

### DIFF
--- a/.changeset/spicy-parrots-sit.md
+++ b/.changeset/spicy-parrots-sit.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Quickfix: Make close button on Modal always actionable

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -110,6 +110,14 @@ const Modal = ({ isOpen, onDismiss, maxWidth, children, asSidebar }) => {
           maxWidth={maxWidth}
           aria-labelledby={headingId}
         >
+          {React.Children?.map(children, child => {
+            // For the heading, we need to provide the id so
+            // aria-labelledby can be linked
+            if (child?.type === Heading) {
+              return React.cloneElement(child, { id: headingId })
+            }
+            return child
+          })}
           <Box
             aria-hidden
             as="button"
@@ -132,14 +140,6 @@ const Modal = ({ isOpen, onDismiss, maxWidth, children, asSidebar }) => {
           >
             <Icon name="cross" size="large" />
           </Box>
-          {React.Children?.map(children, child => {
-            // For the heading, we need to provide the id so
-            // aria-labelledby can be linked
-            if (child?.type === Heading) {
-              return React.cloneElement(child, { id: headingId })
-            }
-            return child
-          })}
         </DialogContent>
       </Box>
     </DialogOverlay>


### PR DESCRIPTION
# What❓

This adds a z-index to the close button on the Model to ensure this button always stays on top and is actionable.

# Why 💁‍♀️

Otherwise it could happen that the modal content overlays the close button and its not clickable anymore