### PR TITLE
Fix styling of `Tabs`

### DIFF
--- a/.changeset/brown-onions-guess.md
+++ b/.changeset/brown-onions-guess.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Fix styling of `Tabs`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@qualifyze/design-system",
-  "version": "1.7.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualifyze/design-system",
-      "version": "1.7.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": "10.1.1",
         "@emotion/styled": "10.0.27",
         "@radix-ui/react-avatar": "^0.1.1",
         "@radix-ui/react-dropdown-menu": "^0.1.0",
-        "@radix-ui/react-tabs": "^0.1.1",
+        "@radix-ui/react-tabs": "0.1.5",
         "@radix-ui/react-visually-hidden": "^0.1.1",
         "@reach/dialog": "^0.15.3",
         "@reach/rect": "^0.15.3",
@@ -5406,17 +5406,16 @@
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-0.1.1.tgz",
-      "integrity": "sha512-JCIquq7yBwteL1/iepc++hVyH5EnSicDXLrU4IrIkCy6W+RKi73htx6K7nRpinhaQL22MbTLDYXo9Rr9X/5bjg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-0.1.5.tgz",
+      "integrity": "sha512-ieVQS1TFr0dX1XA8B+CsSFKOE7kcgEaNWWEfItxj9D1GZjn1o3WqPkW+FhQWDAWZLSKCH2PezYF3MNyO41lgJg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "0.1.0",
         "@radix-ui/react-context": "0.1.1",
-        "@radix-ui/react-id": "0.1.1",
-        "@radix-ui/react-primitive": "0.1.1",
-        "@radix-ui/react-roving-focus": "0.1.1",
-        "@radix-ui/react-use-callback-ref": "0.1.0",
+        "@radix-ui/react-id": "0.1.5",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-roving-focus": "0.1.5",
         "@radix-ui/react-use-controllable-state": "0.1.0"
       },
       "peerDependencies": {
@@ -5424,15 +5423,15 @@
       }
     },
     "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-collection": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-0.1.1.tgz",
-      "integrity": "sha512-WabFzfkvG1uCMHVQd8V++W6qnDqvr+QrbCAXhzzWheKbiXSrwsvA2lTthMn1L6aPn1wyXlX56Xvbzz7Z3nOJAQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-0.1.4.tgz",
+      "integrity": "sha512-3muGI15IdgaDFjOcO7xX8a35HQRBRF6LH9pS6UCeZeRmbslkVeHyJRQr2rzICBUoX7zgIA0kXyMDbpQnJGyJTA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "0.1.0",
         "@radix-ui/react-context": "0.1.1",
-        "@radix-ui/react-primitive": "0.1.1",
-        "@radix-ui/react-slot": "0.1.1"
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-slot": "0.1.2"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
@@ -5450,41 +5449,41 @@
       }
     },
     "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.1.tgz",
-      "integrity": "sha512-Vlg5me65+NUgxPBuA0Lk6FerNe+Mq4EuJ8xzpskGxS2t8p1puI3IkyLZ2wWtDSb1KXazoaHn8adBypagt+1P0g==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.5.tgz",
+      "integrity": "sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-context": "0.1.1"
+        "@radix-ui/react-use-layout-effect": "0.1.0"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
       }
     },
     "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.1.tgz",
-      "integrity": "sha512-65GCHeDV/ikicXKR2rLSO6w+dyUQwSG2J1JD2qm4suK1259nTuRvPsPBrbhZpoXWQKj2drMZfhhclXVfzwW1Kw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
+      "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "0.1.1"
+        "@radix-ui/react-slot": "0.1.2"
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0"
       }
     },
     "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-0.1.1.tgz",
-      "integrity": "sha512-JK60DVpLjn0RsvJ4DnmuKTJGHuqfBID0/xaJ9tTM5DZ9WqHHhMBtaAi+68yZLSfTfQFajXjN7vaKD3UtmAmavA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-0.1.5.tgz",
+      "integrity": "sha512-ClwKPS5JZE+PaHCoW7eu1onvE61pDv4kO8W4t5Ra3qMFQiTJLZMdpBQUhksN//DaVygoLirz4Samdr5Y1x1FSA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "0.1.0",
-        "@radix-ui/react-collection": "0.1.1",
+        "@radix-ui/react-collection": "0.1.4",
         "@radix-ui/react-compose-refs": "0.1.0",
         "@radix-ui/react-context": "0.1.1",
-        "@radix-ui/react-id": "0.1.1",
-        "@radix-ui/react-primitive": "0.1.1",
+        "@radix-ui/react-id": "0.1.5",
+        "@radix-ui/react-primitive": "0.1.4",
         "@radix-ui/react-use-callback-ref": "0.1.0",
         "@radix-ui/react-use-controllable-state": "0.1.0"
       },
@@ -5493,9 +5492,9 @@
       }
     },
     "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
-      "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "0.1.0"
@@ -37082,30 +37081,29 @@
       }
     },
     "@radix-ui/react-tabs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-0.1.1.tgz",
-      "integrity": "sha512-JCIquq7yBwteL1/iepc++hVyH5EnSicDXLrU4IrIkCy6W+RKi73htx6K7nRpinhaQL22MbTLDYXo9Rr9X/5bjg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-0.1.5.tgz",
+      "integrity": "sha512-ieVQS1TFr0dX1XA8B+CsSFKOE7kcgEaNWWEfItxj9D1GZjn1o3WqPkW+FhQWDAWZLSKCH2PezYF3MNyO41lgJg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/primitive": "0.1.0",
         "@radix-ui/react-context": "0.1.1",
-        "@radix-ui/react-id": "0.1.1",
-        "@radix-ui/react-primitive": "0.1.1",
-        "@radix-ui/react-roving-focus": "0.1.1",
-        "@radix-ui/react-use-callback-ref": "0.1.0",
+        "@radix-ui/react-id": "0.1.5",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-roving-focus": "0.1.5",
         "@radix-ui/react-use-controllable-state": "0.1.0"
       },
       "dependencies": {
         "@radix-ui/react-collection": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-0.1.1.tgz",
-          "integrity": "sha512-WabFzfkvG1uCMHVQd8V++W6qnDqvr+QrbCAXhzzWheKbiXSrwsvA2lTthMn1L6aPn1wyXlX56Xvbzz7Z3nOJAQ==",
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-0.1.4.tgz",
+          "integrity": "sha512-3muGI15IdgaDFjOcO7xX8a35HQRBRF6LH9pS6UCeZeRmbslkVeHyJRQr2rzICBUoX7zgIA0kXyMDbpQnJGyJTA==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-compose-refs": "0.1.0",
             "@radix-ui/react-context": "0.1.1",
-            "@radix-ui/react-primitive": "0.1.1",
-            "@radix-ui/react-slot": "0.1.1"
+            "@radix-ui/react-primitive": "0.1.4",
+            "@radix-ui/react-slot": "0.1.2"
           }
         },
         "@radix-ui/react-context": {
@@ -37117,43 +37115,43 @@
           }
         },
         "@radix-ui/react-id": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.1.tgz",
-          "integrity": "sha512-Vlg5me65+NUgxPBuA0Lk6FerNe+Mq4EuJ8xzpskGxS2t8p1puI3IkyLZ2wWtDSb1KXazoaHn8adBypagt+1P0g==",
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.5.tgz",
+          "integrity": "sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==",
           "requires": {
             "@babel/runtime": "^7.13.10",
-            "@radix-ui/react-context": "0.1.1"
+            "@radix-ui/react-use-layout-effect": "0.1.0"
           }
         },
         "@radix-ui/react-primitive": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.1.tgz",
-          "integrity": "sha512-65GCHeDV/ikicXKR2rLSO6w+dyUQwSG2J1JD2qm4suK1259nTuRvPsPBrbhZpoXWQKj2drMZfhhclXVfzwW1Kw==",
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
+          "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
           "requires": {
             "@babel/runtime": "^7.13.10",
-            "@radix-ui/react-slot": "0.1.1"
+            "@radix-ui/react-slot": "0.1.2"
           }
         },
         "@radix-ui/react-roving-focus": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-0.1.1.tgz",
-          "integrity": "sha512-JK60DVpLjn0RsvJ4DnmuKTJGHuqfBID0/xaJ9tTM5DZ9WqHHhMBtaAi+68yZLSfTfQFajXjN7vaKD3UtmAmavA==",
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-0.1.5.tgz",
+          "integrity": "sha512-ClwKPS5JZE+PaHCoW7eu1onvE61pDv4kO8W4t5Ra3qMFQiTJLZMdpBQUhksN//DaVygoLirz4Samdr5Y1x1FSA==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/primitive": "0.1.0",
-            "@radix-ui/react-collection": "0.1.1",
+            "@radix-ui/react-collection": "0.1.4",
             "@radix-ui/react-compose-refs": "0.1.0",
             "@radix-ui/react-context": "0.1.1",
-            "@radix-ui/react-id": "0.1.1",
-            "@radix-ui/react-primitive": "0.1.1",
+            "@radix-ui/react-id": "0.1.5",
+            "@radix-ui/react-primitive": "0.1.4",
             "@radix-ui/react-use-callback-ref": "0.1.0",
             "@radix-ui/react-use-controllable-state": "0.1.0"
           }
         },
         "@radix-ui/react-slot": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.1.tgz",
-          "integrity": "sha512-deq3K7cCXQ+tWMZF2GKl3zGMcwVbyQDiMY/UcPI0Q1DDudRG2dWrEwcYbYajEelc07oOxzNyKpaXZLOpNxquuA==",
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+          "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
           "requires": {
             "@babel/runtime": "^7.13.10",
             "@radix-ui/react-compose-refs": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@emotion/styled": "10.0.27",
     "@radix-ui/react-avatar": "^0.1.1",
     "@radix-ui/react-dropdown-menu": "^0.1.0",
-    "@radix-ui/react-tabs": "^0.1.1",
+    "@radix-ui/react-tabs": "0.1.5",
     "@radix-ui/react-visually-hidden": "^0.1.1",
     "@reach/dialog": "^0.15.3",
     "@reach/rect": "^0.15.3",

--- a/src/components/Tabs/index.jsx
+++ b/src/components/Tabs/index.jsx
@@ -14,6 +14,9 @@ const TabList = styled(TabsPrimitive.List)(props => ({
 }))
 
 const TabTrigger = styled(TabsPrimitive.Trigger)(props => ({
+  'all': 'unset',
+  'border': 'none',
+  'background': 'transparent',
   'position': 'relative',
   'color': props.theme.colors.grey[800],
   'fontWeight': props.theme.fontWeights.semibold,


### PR DESCRIPTION
# What
An upstream change changed the tabs' trigger elements from `<div>`s to `<button>`s
which broke our styling because buttons received the default button
styles (a border and background).

# Before
<img width="788" alt="image" src="https://user-images.githubusercontent.com/6179211/159253511-694ed7ea-3aa8-4cd5-9554-62e599d1ec6c.png">

# After
<img width="791" alt="image" src="https://user-images.githubusercontent.com/6179211/159253523-96a93f68-8ad7-424f-80ec-e50293a00f62.png">

