### PR TITLE
Improve layout for modals and sidebars (QC-1883)

### DIFF
--- a/.changeset/afraid-forks-grow.md
+++ b/.changeset/afraid-forks-grow.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Improve layout for modals and sidebars (QC-1883)

--- a/src/components/Actions/index.jsx
+++ b/src/components/Actions/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import flattenChildren from 'react-keyed-flatten-children'
 
@@ -5,9 +6,6 @@ import Flex from '../Flex'
 
 import ActionsContext from './ActionsContext'
 
-// We need the `.actions` class just to make sure we don't break old designs.
-// For a longer explanation, see the `Button` component.
-// eslint-disable-next-line react/prop-types
 const Actions = ({ children }) => {
   const keyedChildren = flattenChildren(children)
 
@@ -20,6 +18,10 @@ const Actions = ({ children }) => {
       </Flex>
     </ActionsContext.Provider>
   )
+}
+
+Actions.propTypes = {
+  children: PropTypes.node.isRequired,
 }
 
 export default Actions

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -1,23 +1,34 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-// import the base styles for the modal
-import '@reach/dialog/styles.css'
 import {
   DialogContent as BaseDialogContent,
   DialogOverlay as BaseDialogOverlay,
 } from '@reach/dialog'
+// import the base styles for the modal
+import '@reach/dialog/styles.css'
 import { useId } from '@react-aria/utils'
+import PropTypes from 'prop-types'
+import React from 'react'
 
 import { styled } from '../../util/style'
 import BaseActions from '../Actions'
-import BaseHeading from '../Heading'
 import Box from '../Box'
+import BaseHeading from '../Heading'
 import Icon from '../Icon'
 
+const DialogContext = React.createContext()
+
+function useDialog() {
+  return React.useContext(DialogContext)
+}
+
+function useLeftPadding() {
+  const { asSidebar } = useDialog()
+  return asSidebar ? 4 : 3
+}
+
 // eslint-disable-next-line react/prop-types
-const Heading = ({ children, id }) => {
+function Heading({ children, id }) {
   return (
-    <Box sx={{ px: 3, pt: 3, pb: 3, mr: '44px' }}>
+    <Box sx={{ pl: useLeftPadding(), pr: 3, pt: 3, pb: 3, mr: '44px' }}>
       <BaseHeading as="span" level={4} weight="weak" id={id}>
         {children}
       </BaseHeading>
@@ -26,123 +37,157 @@ const Heading = ({ children, id }) => {
 }
 
 // eslint-disable-next-line react/prop-types
-const Body = ({ children }) => <Box sx={{ px: 3, pb: 3 }}>{children}</Box>
+function Body(props) {
+  return (
+    <Box
+      {...props}
+      sx={{
+        pl: useLeftPadding(),
+        pr: 3,
+        pb: 3,
+        flexGrow: 1,
+        overflowY: 'auto',
+        // Read https://css-tricks.com/books/greatest-css-tricks/scroll-shadows/ for an explanation of CSS-only scroll shadows.
+        background: [
+          'linear-gradient(white 30%, rgba(255, 255, 255, 0)) center top',
+          'linear-gradient(rgba(255, 255, 255, 0), white 70%) center bottom',
+          'linear-gradient(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0)) center top',
+          'linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15)) center bottom',
+        ].join(','),
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: '100% 20px, 100% 20px, 100% 7px, 100% 7px',
+        backgroundAttachment: 'local, local, scroll, scroll',
+      }}
+    />
+  )
+}
 
 // eslint-disable-next-line react/prop-types
-const Actions = ({ children }) => (
-  <Box sx={{ px: 3, pb: 3 }}>
-    <BaseActions>{children}</BaseActions>
-  </Box>
-)
+function Actions({ children }) {
+  return (
+    <Box sx={{ py: 3, pl: useLeftPadding(), pr: 3 }}>
+      <BaseActions>{children}</BaseActions>
+    </Box>
+  )
+}
 
 const DialogContent = styled(BaseDialogContent, {
   // prop to the DialogContent
   // in the DOM since its not Do not pass the maxWidth supported
   shouldForwardProp: prop => prop !== 'maxWidth' && prop !== 'asSidebar',
-})(props => {
-  const sideBarDesktopStyles = props.asSidebar
-    ? {
-        padding: props.theme.space[3],
-      }
-    : {}
-  const sideBarMobileStyles = props.asSidebar
-    ? {
-        padding: 0,
-        right: 0,
-        bottom: 0,
-        top: 0,
-        position: 'fixed',
-        overflowY: 'scroll',
-        height: '100%',
-        margin: '0 !important',
-        borderRadius: '0 !important',
-      }
-    : {}
+})(({ theme, asSidebar, maxWidth }) => ({
+  '&[data-reach-dialog-content]': {
+    padding: 0,
+    background: 'white',
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    ...(asSidebar
+      ? {
+          right: 0,
+          bottom: 0,
+          top: 0,
+          position: 'fixed',
+          height: '100%',
+          margin: 0,
+        }
+      : {
+          position: 'relative',
+          margin: '0 auto',
+          maxHeight: '100%',
+        }),
+    [`@media (min-width: ${theme.breakpoints.small})`]: {
+      maxWidth: theme.sizes[maxWidth],
+      width: '75vw',
+      ...(asSidebar
+        ? {}
+        : {
+            borderRadius: theme.radii[2],
+            margin: '10% auto',
+            maxHeight: '80%',
+          }),
+    },
+    [`@media (min-width: ${theme.breakpoints.tablet})`]: {
+      width: '50vw',
+    },
+  },
+}))
+
+const DialogOverlay = styled(BaseDialogOverlay)(({ theme }) => {
   return {
-    '&[data-reach-dialog-content]': {
-      width: `100%`,
-      margin: 0,
-      padding: 0,
-      background: `white`,
-      position: `relative`,
-      marginTop: props.theme.space[6],
-      ...sideBarMobileStyles,
-      [`@media (min-width: ${props.theme.breakpoints.small})`]: {
-        borderRadius: props.theme.radii[2],
-        maxWidth: props.theme.sizes[props.maxWidth],
-        marginBottom: props.theme.space[5],
-        ...sideBarDesktopStyles,
+    '&[data-reach-dialog-overlay]': {
+      background: 'hsla(215, 17%, 30%, 0.9)',
+      zIndex: 500,
+      overflow: 'hidden',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'flex-end',
+      [`@media (min-width: ${theme.breakpoints.small})`]: {
+        justifyContent: 'center',
       },
     },
   }
 })
 
-const DialogOverlay = styled(BaseDialogOverlay)(() => {
-  return {
-    '&[data-reach-dialog-overlay]': {
-      background: 'hsla(215, 17%, 30%, 0.9)',
-      zIndex: 500,
-    },
-  }
-})
+// eslint-disable-next-line react/prop-types
+function DialogCloseButton({ onDismiss }) {
+  return (
+    <Box
+      aria-hidden
+      as="button"
+      onClick={onDismiss}
+      sx={{
+        appearance: 'none',
+        textDecoration: 'none !important',
+        border: 0,
+        cursor: 'pointer',
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bg: 'transparent',
+        width: '44px',
+        height: '44px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Icon name="cross" size="large" />
+    </Box>
+  )
+}
 
 // this is the base modal it is very basic right now we use the overlay and the content
 // as we add custom styling to both of these components. if the custom styling is
 // removed we can just use the Dialog component that comes from the plugin
-const Modal = ({ isOpen, onDismiss, maxWidth, children, asSidebar }) => {
+const Modal = ({ isOpen, onDismiss, children, maxWidth, asSidebar }) => {
+  const context = React.useMemo(() => ({ asSidebar }), [asSidebar])
   const headingId = useId()
 
+  // For the heading, we need to provide the id so
+  // aria-labelledby can be linked
+  const heading = React.Children.map(children, child =>
+    child.type === Heading ? React.cloneElement(child, { id: headingId }) : null
+  ).filter(Boolean)
+
+  const body = React.Children.map(children, child =>
+    child.type === Heading ? null : child
+  ).filter(Boolean)
+
   return (
-    <DialogOverlay isOpen={isOpen} onDismiss={onDismiss}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: ['flex-end', 'center'],
-          justifyContent: 'center',
-          minHeight: '100%',
-          bg: 'transparent',
-          boxShadow: 8,
-          px: [0, 3],
-        }}
-      >
+    <DialogContext.Provider value={context}>
+      <DialogOverlay isOpen={isOpen} onDismiss={onDismiss}>
         <DialogContent
-          asSidebar={asSidebar}
-          maxWidth={maxWidth}
           aria-labelledby={headingId}
+          maxWidth={maxWidth}
+          asSidebar={asSidebar}
         >
-          {React.Children?.map(children, child => {
-            // For the heading, we need to provide the id so
-            // aria-labelledby can be linked
-            if (child?.type === Heading) {
-              return React.cloneElement(child, { id: headingId })
-            }
-            return child
-          })}
-          <Box
-            aria-hidden
-            as="button"
-            onClick={onDismiss}
-            sx={{
-              appearance: 'none',
-              textDecoration: 'none !important',
-              border: 0,
-              cursor: 'pointer',
-              position: 'absolute',
-              top: 0,
-              right: 0,
-              bg: 'transparent',
-              width: '44px',
-              height: '44px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Icon name="cross" size="large" />
-          </Box>
+          {heading}
+          {body}
+          <DialogCloseButton onDismiss={onDismiss} />
         </DialogContent>
-      </Box>
-    </DialogOverlay>
+      </DialogOverlay>
+    </DialogContext.Provider>
   )
 }
 

--- a/src/components/Modal/index.stories.jsx
+++ b/src/components/Modal/index.stories.jsx
@@ -1,60 +1,128 @@
-import React, { useState } from 'react'
-import { Formik, Form } from 'formik'
-import * as Yup from 'yup'
 import { action } from '@storybook/addon-actions'
+import { boolean } from '@storybook/addon-knobs'
+import { Form, Formik } from 'formik'
+import React, { useState } from 'react'
+import * as Yup from 'yup'
 
 import Box from '../Box'
-import Stack from '../Stack'
 import Button from '../Button'
-import Text from '../Text'
+import Inline from '../Inline'
 import SelectField from '../SelectField'
+import Stack from '../Stack'
+import Text from '../Text'
 
 import Modal from './index'
 
 export default { title: 'Modal', component: Modal }
 
 export const Default = () => {
+  const withSelect = boolean('With select input')
+  const longContent = boolean('Long content')
+  const asSidebar = boolean('Sidebar')
   const [isOpen, setIsOpen] = useState(false)
 
   return (
     <>
-      <Box>
-        <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-      </Box>
-      <Modal isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
-        <Modal.Heading>
-          This is probably the most-used type of Modal
-        </Modal.Heading>
+      <Stack space={3}>
+        <Text>Use the knobs to control the behavior of the modal.</Text>
+        <Inline>
+          <Button onClick={() => setIsOpen(true)}>Open modal</Button>
+        </Inline>
+      </Stack>
+      <Modal
+        isOpen={isOpen}
+        asSidebar={asSidebar}
+        onDismiss={() => setIsOpen(false)}
+      >
+        <Modal.Heading>Hello, World!</Modal.Heading>
         <Modal.Body>
           <Stack space={3}>
+            {withSelect && (
+              <Formik
+                initialValues={{ option: '' }}
+                onSubmit={values =>
+                  action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
+                }
+                validationSchema={Yup.object().shape({
+                  option: Yup.string().required(),
+                })}
+              >
+                <Form>
+                  <SelectField
+                    options={[
+                      { label: 'Option 1', value: '1' },
+                      { label: 'Option 2', value: '2' },
+                      { label: 'Option 3', value: '3' },
+                      { label: 'Option 4', value: '4' },
+                    ]}
+                    placeholder="select a thing"
+                    name="option"
+                    label="some selection"
+                  />
+                </Form>
+              </Formik>
+            )}
+            {longContent && (
+              <>
+                <Text>
+                  Veggies es bonus vobis, proinde vos postulo essum magis
+                  kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon
+                  azuki bean garlic.
+                </Text>
+                <Text>
+                  Gumbo beet greens corn soko endive gumbo gourd. Parsley
+                  shallot courgette tatsoi pea sprouts fava bean collard greens
+                  dandelion okra wakame tomato. Dandelion cucumber earthnut pea
+                  peanut soko zucchini.
+                </Text>
+                <Text>
+                  Turnip greens yarrow ricebean rutabaga endive cauliflower sea
+                  lettuce kohlrabi amaranth water spinach avocado daikon napa
+                  cabbage asparagus winter purslane kale. Celery potato scallion
+                  desert raisin horseradish spinach carrot soko. Lotus root
+                  water spinach fennel kombu maize bamboo shoot green bean swiss
+                  chard seakale pumpkin onion chickpea gram corn pea. Brussels
+                  sprout coriander water chestnut gourd swiss chard wakame
+                  kohlrabi beetroot carrot watercress. Corn amaranth salsify
+                  bunya nuts nori azuki bean chickweed potato bell pepper
+                  artichoke.
+                </Text>
+                <Text>
+                  Nori grape silver beet broccoli kombu beet greens fava bean
+                  potato quandong celery. Bunya nuts black-eyed pea prairie
+                  turnip leek lentil turnip greens parsnip. Sea lettuce lettuce
+                  water chestnut eggplant winter purslane fennel azuki bean
+                  earthnut pea sierra leone bologi leek soko chicory celtuce
+                  parsley jicama salsify.
+                </Text>
+                <Text>
+                  Celery quandong swiss chard chicory earthnut pea potato.
+                  Salsify taro catsear garlic gram celery bitterleaf wattle seed
+                  collard greens nori. Grape wattle seed kombu beetroot
+                  horseradish carrot squash brussels sprout chard.
+                </Text>
+                <Text>
+                  Pea horseradish azuki bean lettuce avocado asparagus okra.
+                  Kohlrabi radish okra azuki bean corn fava bean mustard
+                  tigernut jicama green bean celtuce collard greens avocado
+                  quandong fennel gumbo black-eyed pea. Grape silver beet
+                  watercress potato tigernut corn groundnut. Chickweed okra pea
+                  winter purslane coriander yarrow sweet pepper radish garlic
+                  brussels sprout groundnut summer purslane earthnut pea tomato
+                  spring onion azuki bean gourd. Gumbo kakadu plum komatsuna
+                  black-eyed pea green bean zucchini gourd winter purslane
+                  silver beet rock melon radish asparagus spinach.
+                </Text>
+              </>
+            )}
             <Text>
-              We provide three compound components that you can use to structure
-              your modal:{' '}
-            </Text>
-            <Text as="pre" weight="medium">
-              Modal.Heading
-            </Text>{' '}
-            <Text as="pre" weight="medium">
-              Modal.Body
-            </Text>{' '}
-            <Text as="pre" weight="medium">
-              Modal.Actions
-            </Text>{' '}
-            <Text>
-              Note: You still need to wrap Text around your all text you want to
-              show in the Modal.Body.
-            </Text>
-            <Text size="large" weight="strong">
-              Please use these.
-            </Text>
-            <Text>
-              Note: The primary Button should always come first, secondary after
-              that.
+              Note: The primary action should always come first, any secondary
+              actions after that.
             </Text>
           </Stack>
         </Modal.Body>
         <Modal.Actions>
-          <Button onClick={() => setIsOpen(false)}>Alright then!</Button>
+          <Button onClick={() => setIsOpen(false)}>OK</Button>
           <Button variant="secondary" onClick={() => setIsOpen(false)}>
             Close
           </Button>
@@ -63,6 +131,7 @@ export const Default = () => {
     </>
   )
 }
+
 Default.story = {
   name: 'default',
 }
@@ -84,220 +153,4 @@ export const Bare = () => {
 }
 Bare.story = {
   name: 'bare Modal',
-}
-
-export const Long = () => {
-  const [isOpen, setIsOpen] = useState(false)
-
-  return (
-    <>
-      <Box>
-        <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-      </Box>
-      <Modal isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
-        <Modal.Heading>Soko radicchio bunya nuts gram dulse</Modal.Heading>
-        <Modal.Body>
-          <Stack space={3}>
-            <Text>
-              Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi
-              welsh onion daikon amaranth tatsoi tomatillo melon azuki bean
-              garlic.
-            </Text>
-            <Text>
-              Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot
-              courgette tatsoi pea sprouts fava bean collard greens dandelion
-              okra wakame tomato. Dandelion cucumber earthnut pea peanut soko
-              zucchini.
-            </Text>
-            <Text>
-              Turnip greens yarrow ricebean rutabaga endive cauliflower sea
-              lettuce kohlrabi amaranth water spinach avocado daikon napa
-              cabbage asparagus winter purslane kale. Celery potato scallion
-              desert raisin horseradish spinach carrot soko. Lotus root water
-              spinach fennel kombu maize bamboo shoot green bean swiss chard
-              seakale pumpkin onion chickpea gram corn pea. Brussels sprout
-              coriander water chestnut gourd swiss chard wakame kohlrabi
-              beetroot carrot watercress. Corn amaranth salsify bunya nuts nori
-              azuki bean chickweed potato bell pepper artichoke.
-            </Text>
-            <Text>
-              Nori grape silver beet broccoli kombu beet greens fava bean potato
-              quandong celery. Bunya nuts black-eyed pea prairie turnip leek
-              lentil turnip greens parsnip. Sea lettuce lettuce water chestnut
-              eggplant winter purslane fennel azuki bean earthnut pea sierra
-              leone bologi leek soko chicory celtuce parsley jï¿½cama salsify.
-            </Text>
-            <Text>
-              Celery quandong swiss chard chicory earthnut pea potato. Salsify
-              taro catsear garlic gram celery bitterleaf wattle seed collard
-              greens nori. Grape wattle seed kombu beetroot horseradish carrot
-              squash brussels sprout chard.
-            </Text>
-            <Text>
-              Pea horseradish azuki bean lettuce avocado asparagus okra.
-              Kohlrabi radish okra azuki bean corn fava bean mustard tigernut
-              jï¿½cama green bean celtuce collard greens avocado quandong fennel
-              gumbo black-eyed pea. Grape silver beet watercress potato tigernut
-              corn groundnut. Chickweed okra pea winter purslane coriander
-              yarrow sweet pepper radish garlic brussels sprout groundnut summer
-              purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo
-              kakadu plum komatsuna black-eyed pea green bean zucchini gourd
-              winter purslane silver beet rock melon radish asparagus spinach.
-            </Text>
-          </Stack>
-        </Modal.Body>
-        <Modal.Actions>
-          <Button onClick={() => setIsOpen(false)}>Do something fun</Button>
-          <Button variant="secondary" onClick={() => setIsOpen(false)}>
-            Close
-          </Button>
-        </Modal.Actions>
-      </Modal>
-    </>
-  )
-}
-Long.story = {
-  name: 'a lot of content',
-}
-
-const selectSchema = Yup.object().shape({
-  option: Yup.string().required(),
-})
-
-export const WithSelect = () => {
-  const [isOpen, setIsOpen] = useState(false)
-
-  return (
-    <>
-      <Box>
-        <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-      </Box>
-      <Modal isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
-        <Modal.Heading>This is an item with a select</Modal.Heading>
-        <Modal.Body>
-          <Formik
-            initialValues={{
-              option: '',
-            }}
-            onSubmit={values => {
-              action(`Submitted! ${JSON.stringify(values, undefined, 2)}`)
-            }}
-            validationSchema={selectSchema}
-          >
-            {() => (
-              <Form>
-                <SelectField
-                  options={[
-                    {
-                      label: 'Option 1',
-                      value: '1',
-                    },
-                    {
-                      label: 'Option 2',
-                      value: '2',
-                    },
-                    {
-                      label: 'Option 3',
-                      value: '3',
-                    },
-                    {
-                      label: 'Option 4',
-                      value: '4',
-                    },
-                  ]}
-                  placeholder="select a thing"
-                  name="option"
-                  label="some selection"
-                  menuPlacement="top"
-                />
-              </Form>
-            )}
-          </Formik>
-        </Modal.Body>
-        <Modal.Actions>
-          <Button onClick={() => setIsOpen(false)}>Do something fun</Button>
-          <Button variant="secondary" onClick={() => setIsOpen(false)}>
-            Close
-          </Button>
-        </Modal.Actions>
-      </Modal>
-    </>
-  )
-}
-WithSelect.story = {
-  name: 'with a select input',
-}
-
-export const AsSidebar = () => {
-  const [isOpen, setIsOpen] = useState(false)
-
-  return (
-    <>
-      <Box>
-        <Button onClick={() => setIsOpen(true)}>Open modal</Button>
-      </Box>
-      <Modal isOpen={isOpen} onDismiss={() => setIsOpen(false)} asSidebar>
-        <Modal.Heading>This is an item which is a side bar</Modal.Heading>
-        <Modal.Body>
-          <Stack space={3}>
-            <Text>
-              Veggies es bonus vobis, proinde vos postulo essum magis kohlrabi
-              welsh onion daikon amaranth tatsoi tomatillo melon azuki bean
-              garlic.
-            </Text>
-            <Text>
-              Gumbo beet greens corn soko endive gumbo gourd. Parsley shallot
-              courgette tatsoi pea sprouts fava bean collard greens dandelion
-              okra wakame tomato. Dandelion cucumber earthnut pea peanut soko
-              zucchini.
-            </Text>
-            <Text>
-              Turnip greens yarrow ricebean rutabaga endive cauliflower sea
-              lettuce kohlrabi amaranth water spinach avocado daikon napa
-              cabbage asparagus winter purslane kale. Celery potato scallion
-              desert raisin horseradish spinach carrot soko. Lotus root water
-              spinach fennel kombu maize bamboo shoot green bean swiss chard
-              seakale pumpkin onion chickpea gram corn pea. Brussels sprout
-              coriander water chestnut gourd swiss chard wakame kohlrabi
-              beetroot carrot watercress. Corn amaranth salsify bunya nuts nori
-              azuki bean chickweed potato bell pepper artichoke.
-            </Text>
-            <Text>
-              Nori grape silver beet broccoli kombu beet greens fava bean potato
-              quandong celery. Bunya nuts black-eyed pea prairie turnip leek
-              lentil turnip greens parsnip. Sea lettuce lettuce water chestnut
-              eggplant winter purslane fennel azuki bean earthnut pea sierra
-              leone bologi leek soko chicory celtuce parsley jï¿½cama salsify.
-            </Text>
-            <Text>
-              Celery quandong swiss chard chicory earthnut pea potato. Salsify
-              taro catsear garlic gram celery bitterleaf wattle seed collard
-              greens nori. Grape wattle seed kombu beetroot horseradish carrot
-              squash brussels sprout chard.
-            </Text>
-            <Text>
-              Pea horseradish azuki bean lettuce avocado asparagus okra.
-              Kohlrabi radish okra azuki bean corn fava bean mustard tigernut
-              jï¿½cama green bean celtuce collard greens avocado quandong fennel
-              gumbo black-eyed pea. Grape silver beet watercress potato tigernut
-              corn groundnut. Chickweed okra pea winter purslane coriander
-              yarrow sweet pepper radish garlic brussels sprout groundnut summer
-              purslane earthnut pea tomato spring onion azuki bean gourd. Gumbo
-              kakadu plum komatsuna black-eyed pea green bean zucchini gourd
-              winter purslane silver beet rock melon radish asparagus spinach.
-            </Text>
-          </Stack>
-        </Modal.Body>
-        <Modal.Actions>
-          <Button onClick={() => setIsOpen(false)}>Do something fun</Button>
-          <Button variant="secondary" onClick={() => setIsOpen(false)}>
-            Close
-          </Button>
-        </Modal.Actions>
-      </Modal>
-    </>
-  )
-}
-AsSidebar.story = {
-  name: 'As a side bar',
 }

--- a/src/components/SelectField/baseTheme.jsx
+++ b/src/components/SelectField/baseTheme.jsx
@@ -140,6 +140,10 @@ export const customStyles = {
     overflow: 'initial',
     wordBreak: 'break-word',
   }),
+  menuPortal: provided => ({
+    ...provided,
+    zIndex: 9999,
+  }),
 }
 
 export const defaultVariant = customTheme => ({

--- a/src/components/SelectField/index.jsx
+++ b/src/components/SelectField/index.jsx
@@ -62,6 +62,8 @@ const SelectField = ({
         }
         isDisabled={disabled}
         menuPlacement={menuPlacement}
+        menuPortalTarget={window.document.body}
+        menuPosition="absolute"
         noOptionsMessage={noOptionsMessage}
         components={{ DropdownIndicator }}
       />


### PR DESCRIPTION
# What❓

Improved the layout of the sidebar and dialog component:
* The actions of the sidebar are now always at the bottom of the screen.
* On small screens the sidebar behaves exactly like a regular dialog.
* On small screens all dialogs are now displayed full-screen.
* Better scrolling behavior for long content: the header and actions now stay fixed and only the content scrolls.
* The dialog actions are now always inlined, even on small screens.

# Screenshots

## Dialog on desktop

![dialog-short-desktop](https://user-images.githubusercontent.com/1437300/161510075-2690fdf5-a06e-499a-afa9-0206eff739f2.png)
![dialog-long-desktop](https://user-images.githubusercontent.com/1437300/161510072-7be3798c-3d08-4e49-94ff-7eba64a25a6a.png)

## Dialog on mobile

![dialog-short-mobile](https://user-images.githubusercontent.com/1437300/161510077-36d4b1b7-839f-4f20-a26d-e78de0ef1dcb.png)
![dialog-long-mobile](https://user-images.githubusercontent.com/1437300/161510073-2921aeac-dd5c-4f06-a709-ac2ad0ca1652.png)

## Sidebar on desktop

![sidebar-short-desktop](https://user-images.githubusercontent.com/1437300/161510083-bbd382f8-afe1-482c-8b0d-faecd7c932cf.png)
![sidebar-long-desktop](https://user-images.githubusercontent.com/1437300/161510079-4f882fd8-104d-4704-944c-79d0ba8fca3b.png)

## Sidebar on mobile

![sidebar-long-mobile](https://user-images.githubusercontent.com/1437300/161510081-761fc417-ba88-4c98-bd6c-caf486a4acf1.png)
