### PR TITLE
Use gap instead of negative margins in Stack component

### DIFF
--- a/.changeset/empty-crabs-tell.md
+++ b/.changeset/empty-crabs-tell.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Use gap instead of negative margins for Stack component

--- a/src/components/Stack/index.jsx
+++ b/src/components/Stack/index.jsx
@@ -10,8 +10,12 @@ import Box from '../Box'
 import useNegativeValue from '../private/hooks/useNegativeValue'
 
 const useStackItem = ({ align, space }) => ({
-  pt: space,
-  width: '100%',
+  'pt': space,
+  // if browser supports gap, revert using margins
+  '@supports (gap: 10px)': {
+    pt: 0,
+  },
+  'width': '100%',
   // If we're aligned left across all screen sizes,
   // there's actually no alignment work to do.
   ...(align === 'left'
@@ -36,10 +40,20 @@ const Stack = ({ as, space, children, align }) => {
       as={as}
       sx={{
         'position': 'static',
+        'display': 'flex',
+        'flex-direction': 'column',
+        // 10 is a dummy value to test if browser supports gap (Internet Explorer doesn't)
+        '@supports (gap: 10px)': {
+          gap: space,
+        },
         '&::before': {
-          content: '""',
-          display: 'table',
-          mt: useNegativeValue(space),
+          'content': '""',
+          'display': 'table',
+          'mt': useNegativeValue(space),
+          // if browser supports gap, revert using margins
+          '@supports (gap: 10px)': {
+            mt: 0,
+          },
         },
       }}
     >


### PR DESCRIPTION
# What❓

Use `gap` property for creating spaces in between child components of Stack. If we like it, we can roll out similar solutions to the other leaking components.

# Why 💁‍♀️

I think we can do a bit better to avoid leaking-prone components to generate problems, at least for most users (in our case, non Internet Explorer users).
New `gap` property provides same value while being making the component less prone to "leaking". 
Internet Explorer browsers doesn't support it, for which we keep old behavior.

# How to test ✅

1. Go to to the stories under "Stack", pick "leaking example".
2. Under tab "Knobs", untick "Using z-index".
3. Pick values for "Space" over `4`.
4. Try to click on the upper button, it should be clickable.
