### PR TITLE
Drop IE11 for `Inline` in favor of flexbox's `gap`

### DIFF
--- a/src/components/Actions/index.jsx
+++ b/src/components/Actions/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import flattenChildren from 'react-keyed-flatten-children'
 
-import Inline from '../Inline'
+import Flex from '../Flex'
 
 import ActionsContext from './ActionsContext'
 
@@ -8,11 +9,15 @@ import ActionsContext from './ActionsContext'
 // For a longer explanation, see the `Button` component.
 // eslint-disable-next-line react/prop-types
 const Actions = ({ children }) => {
+  const keyedChildren = flattenChildren(children)
+
   return (
     <ActionsContext.Provider value={{}}>
-      <Inline space={3} collapseBelow="mobile">
-        {children}
-      </Inline>
+      <Flex sx={{ flexDirection: ['column', 'row'], gap: 3 }}>
+        {React.Children.map(keyedChildren, child => {
+          return <Flex sx={{ width: ['100%', 'auto'] }}>{child}</Flex>
+        })}
+      </Flex>
     </ActionsContext.Provider>
   )
 }

--- a/src/components/Inline/__tests__/useAlignment.js
+++ b/src/components/Inline/__tests__/useAlignment.js
@@ -6,15 +6,13 @@ describe('useAlignment', () => {
     const alignBottom = useAlignment('bottom')
     const alignCenter = useAlignment('center')
 
-    expect(alignTop).toEqual({ alignItems: 'flex-start' })
-    expect(alignBottom).toEqual({ alignItems: 'flex-end' })
-    expect(alignCenter).toEqual({ alignItems: 'center' })
+    expect(alignTop).toEqual('flex-start')
+    expect(alignBottom).toEqual('flex-end')
+    expect(alignCenter).toEqual('center')
   })
 
   test('when you pass a responsive array you should get out an array', () => {
     const responsiveAlignment = useAlignment(['top', 'bottom', 'center'])
-    expect(responsiveAlignment).toEqual({
-      alignItems: ['flex-start', 'flex-end', 'center'],
-    })
+    expect(responsiveAlignment).toEqual(['flex-start', 'flex-end', 'center'])
   })
 })

--- a/src/components/Inline/index.jsx
+++ b/src/components/Inline/index.jsx
@@ -3,51 +3,27 @@
  *
  * Note: Currently, it's not possible to use <Hidden> inside an <Inline>. This needs more work, but I'm not sure if we will actually need it...
  */
-import React, { Children } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
-import flattenChildren from 'react-keyed-flatten-children'
 
 import { propType } from '../../util/style'
 import Box from '../Box'
-import Flex from '../Flex'
-import useNegativeValue from '../private/hooks/useNegativeValue'
 
 import useFlexDirection from './useFlexDirection'
 import useAlignment from './useAlignment'
 
 const Inline = ({ space, collapseBelow, alignY, children }) => {
-  const inlineItems = flattenChildren(children)
-
   return (
     <Box
       sx={{
-        'position': 'static',
-        '&::before': {
-          content: '""',
-          display: 'table',
-          mt: useNegativeValue(space),
-        },
+        display: 'inline-flex',
+        flexWrap: 'wrap',
+        flexDirection: useFlexDirection(collapseBelow),
+        alignItems: useAlignment(alignY),
+        gap: space,
       }}
     >
-      <Flex
-        flexWrap="wrap"
-        flexDirection={useFlexDirection(collapseBelow)}
-        {...useAlignment(alignY)}
-        sx={{
-          'position': 'static',
-          '&::before': {
-            content: '""',
-            display: 'table',
-            ml: useNegativeValue(space),
-          },
-        }}
-      >
-        {Children.map(inlineItems, child => {
-          return (
-            <Box sx={{ pl: space, pt: space, position: 'static' }}>{child}</Box>
-          )
-        })}
-      </Flex>
+      {children}
     </Box>
   )
 }
@@ -67,6 +43,7 @@ Inline.propTypes = {
   space: propType,
   /** Shows components in a single column below this breakpoint */
   collapseBelow: PropTypes.oneOf(['mobile', 'tablet', 'desktop']),
+  /** Vertical alignment of components */
   alignY: PropTypes.oneOfType([alignYValues, PropTypes.arrayOf(alignYValues)]),
 }
 

--- a/src/components/Inline/index.stories.jsx
+++ b/src/components/Inline/index.stories.jsx
@@ -1,9 +1,7 @@
 /* eslint-disable no-alert */
 import React from 'react'
-import { boolean, select } from '@storybook/addon-knobs'
+import { select } from '@storybook/addon-knobs'
 
-import Box from '../Box'
-import Button from '../Button'
 import Placeholder from '../private/Placeholder'
 
 import Inline from './index'
@@ -81,64 +79,4 @@ export const AlignY = () => {
 }
 AlignY.story = {
   name: 'vertically aligned',
-}
-
-export const Adjacent = () => {
-  const space = select('Space', ALL_SPACES, 5)
-
-  return (
-    <Box css={{ display: 'flex', flexDirection: 'row' }}>
-      <Inline>
-        <Button onClick={() => alert('Yes i am!')}>Am I clickable?</Button>
-      </Inline>
-      <Inline space={space}>
-        <Placeholder width={50} height={50} />
-        <Placeholder width={50} height={50} />
-        <Placeholder width={50} height={50} />
-      </Inline>
-    </Box>
-  )
-}
-Adjacent.story = {
-  name: 'with adjacent interactive elements',
-}
-
-export const LeakingExample = () => {
-  const space = select('Space', ALL_SPACES, 7)
-  const withIndex = boolean('Using z-index', true)
-
-  return (
-    <Box
-      css={{
-        display: 'flex',
-        flexDirection: 'row',
-      }}
-    >
-      <Box
-        sx={{
-          zIndex: withIndex ? '2' : null,
-        }}
-      >
-        <Inline>
-          <Button onClick={() => alert('Yes i am!')}>
-            Am I clickable? Try with high space values
-          </Button>
-        </Inline>
-      </Box>
-      <Box
-        sx={{
-          zIndex: withIndex ? '1' : null,
-        }}
-      >
-        <Inline space={space}>
-          <Placeholder width={50} height={50} />
-          <Placeholder width={50} height={50} />
-          <Placeholder width={50} height={50} />
-        </Inline>
-      </Box>
-    </Box>
-  )
-}
-LeakingExample.story = {
-  name: 'leaking example',
 }

--- a/src/components/Inline/useAlignment.js
+++ b/src/components/Inline/useAlignment.js
@@ -17,19 +17,11 @@ const transformAlign = direction => {
   return alignment
 }
 
-const getValues = values => {
+const useAlignment = values => {
   if (Array.isArray(values)) {
     return values.map(a => transformAlign(a))
   }
   return transformAlign(values)
-}
-
-const useAlignment = x => {
-  const alignment = getValues(x)
-
-  return {
-    alignItems: alignment,
-  }
 }
 
 export default useAlignment


### PR DESCRIPTION
We decided it's time to drop IE11 support for our `Inline` component in
favor of using `flexbox`'s `gap` property. Previously, we tried to avoid
`gap` (because it's not supported by IE11) but this has lead to some
gnarly issues with negative margins.
