### PR TITLE
☂️ Drop IE11 support in layout components in favor of using flexbox's `gap` property

### DIFF
--- a/.changeset/silent-cobras-yell.md
+++ b/.changeset/silent-cobras-yell.md
@@ -1,0 +1,12 @@
+---
+'@qualifyze/design-system': major
+---
+
+Drop IE11 support in layout components in favor of using flexbox's `gap` property. The affected layout components are:
+
+- `Stack`
+- `Inline`
+- `Tiles`
+- `Columns`
+
+These will probably just not have any whitespace between their child components in IE11.

--- a/src/components/Actions/index.jsx
+++ b/src/components/Actions/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import flattenChildren from 'react-keyed-flatten-children'
 
-import Inline from '../Inline'
+import Flex from '../Flex'
 
 import ActionsContext from './ActionsContext'
 
@@ -8,11 +9,15 @@ import ActionsContext from './ActionsContext'
 // For a longer explanation, see the `Button` component.
 // eslint-disable-next-line react/prop-types
 const Actions = ({ children }) => {
+  const keyedChildren = flattenChildren(children)
+
   return (
     <ActionsContext.Provider value={{}}>
-      <Inline space={3} collapseBelow="mobile">
-        {children}
-      </Inline>
+      <Flex sx={{ flexDirection: ['column', 'row'], gap: 3 }}>
+        {React.Children.map(keyedChildren, child => {
+          return <Flex sx={{ width: ['100%', 'auto'] }}>{child}</Flex>
+        })}
+      </Flex>
     </ActionsContext.Provider>
   )
 }

--- a/src/components/Column/index.jsx
+++ b/src/components/Column/index.jsx
@@ -10,7 +10,7 @@ const resolveWidth = {
 }
 
 const Column = ({ width, children }) => {
-  const { pt, pl, defaultWidth } = useContext(ColumnsContext)
+  const { defaultWidth } = useContext(ColumnsContext)
 
   // If width is `auto`, we need to make sure the column doesn't break lines
   const preventBreak = width === 'auto'
@@ -18,11 +18,8 @@ const Column = ({ width, children }) => {
   return (
     <Box
       sx={{
-        pt,
-        pl,
         width: resolveWidth[width] ?? width ?? defaultWidth,
         flexShrink: preventBreak ? 0 : null,
-        position: 'static',
       }}
     >
       {children}

--- a/src/components/Column/index.stories.jsx
+++ b/src/components/Column/index.stories.jsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { text, select } from '@storybook/addon-knobs'
 
-import Box from '../Box'
-import Button from '../Button'
 import Columns from '../Columns'
 import Placeholder from '../private/Placeholder'
 
@@ -74,33 +72,4 @@ export const AutoWidth = () => (
 )
 AutoWidth.story = {
   name: 'automatic width',
-}
-
-export const Adjacent = () => {
-  const space = select('Space', ALL_SPACES, 5)
-
-  return (
-    <Box sx={{ display: 'flex' }}>
-      <Box>
-        <Button>Am I clickable?</Button>
-      </Box>
-      <Columns space={space}>
-        <Column>
-          <Placeholder height={50} width="100%" label="hello there" />
-        </Column>
-        <Column>
-          <Placeholder height={50} width="100%" label="hello there" />
-        </Column>
-        <Column>
-          <Placeholder height={50} width="100%" label="hello there" />
-        </Column>
-        <Column>
-          <Placeholder height={50} width="100%" label="hello there" />
-        </Column>
-      </Columns>
-    </Box>
-  )
-}
-Adjacent.story = {
-  name: 'with adjacent interactive elements',
 }

--- a/src/components/Columns/index.jsx
+++ b/src/components/Columns/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 
 import { propTypes } from '../../util/style'
 import Flex from '../Flex'
-import useNegativeValue from '../private/hooks/useNegativeValue'
 
 import useDefaultWidth from './useDefaultWidth'
 import useFlexAlignment from './useFlexAlignment'
@@ -16,23 +15,6 @@ export const ColumnsContext = createContext({
   defaultWidth: '100%',
 })
 
-// -----
-// align: 'center' | 'right' | 'left' || Array < 'center' | 'right' | 'left' >
-//   How children will align top to bottom, can also be an array of how the children will align
-//   at breakpoints
-// -----
-// alignY: 'center' | 'top' | 'bottom' || Array<'center' | 'top' | 'bottom'>
-//   How children will align along you y axis so top to bottom, can also be an array for
-//   responsive props
-// -----
-// collapseBellow:? 'mobile' | 'tablet' | 'desktop'
-//   At what breakpoint would you like to collapse into cols mode, this is most of the time
-//   just mobile, but if you want to keep a row just don't supply anything here
-// -----
-// space:?propTypes.space
-//   Optional prop for how to space out the children also can be responsive array
-// -----
-
 const Columns = ({ children, collapseBelow, space, alignY, align }) => {
   // calculate the default width to use if none if provided for the children
   // add it to the context so each col can just use the default width per item
@@ -41,19 +23,15 @@ const Columns = ({ children, collapseBelow, space, alignY, align }) => {
 
   return (
     <Flex
-      {...useFlexAlignment(align, alignY, collapseBelow)}
-      flexDirection={useFlexDirection(collapseBelow)}
-      flexWrap={useFlexWrap(collapseBelow)}
       sx={{
-        position: 'static',
-        mt: useNegativeValue(space),
-        ml: useNegativeValue(space),
+        flexWrap: useFlexWrap(collapseBelow),
+        flexDirection: useFlexDirection(collapseBelow),
+        ...useFlexAlignment(align, alignY, collapseBelow),
+        gap: space,
       }}
     >
       <ColumnsContext.Provider
         value={{
-          pl: space,
-          pt: space,
           defaultWidth,
         }}
       >
@@ -69,7 +47,6 @@ Columns.defaultProps = {
   alignY: 'top',
 }
 
-// enums for prop checking
 const alignValues = PropTypes.oneOf(['left', 'right', 'center', 'fill'])
 const alignYValues = PropTypes.oneOf(['top', 'bottom', 'center', 'stretch'])
 
@@ -78,9 +55,13 @@ Columns.propTypes = {
     PropTypes.arrayOf(PropTypes.element),
     PropTypes.element,
   ]).isRequired,
+  /** Breakpoint for when columns should appear stacked vertically */
   collapseBelow: PropTypes.oneOf(['mobile', 'tablet', 'desktop']),
+  /** Spacing between child components */
   ...propTypes.space,
+  /** Vertical alignment of child components */
   alignY: PropTypes.oneOfType([alignYValues, PropTypes.arrayOf(alignYValues)]),
+  /** Horizontal alignment of child components */
   align: PropTypes.oneOfType([alignValues, PropTypes.arrayOf(alignValues)]),
 }
 

--- a/src/components/Columns/index.stories.jsx
+++ b/src/components/Columns/index.stories.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import { select, number, array, text, boolean } from '@storybook/addon-knobs'
+import { select, number, array, text } from '@storybook/addon-knobs'
 
 import Column from '../Column'
 import Box from '../Box'
-import Inline from '../Inline'
 import Text from '../Text'
 import Card from '../Card'
 import Button from '../Button'
@@ -172,55 +171,4 @@ export const ExampleWithButton = () => {
 }
 ExampleWithButton.story = {
   name: 'example with Button',
-}
-
-// All possible values for `space` according to our theme
-const ALL_SPACES = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-
-export const LeakingExample = () => {
-  const space = select('Space', ALL_SPACES, 6)
-  const withIndex = boolean('Using z-index', true)
-
-  // eslint-disable-next-line no-alert
-  const click = () => alert('Yes I am!')
-
-  return (
-    <Box>
-      <Card>
-        <Stack space={3}>
-          <Box
-            sx={{
-              zIndex: withIndex ? '2' : null,
-            }}
-          >
-            <Inline>
-              <Button onClick={click}>
-                Am I clickable? Try with high space values
-              </Button>
-            </Inline>
-          </Box>
-          <Box
-            sx={{
-              zIndex: withIndex ? '1' : null,
-            }}
-          >
-            <Columns space={space} collapseBelow="mobile">
-              <Column width="fill">
-                <Text>
-                  Your comments over the report had been uploaded. We will
-                  upload the final report shortly.
-                </Text>
-              </Column>
-              <Column width="auto">
-                <Button>Continue</Button>
-              </Column>
-            </Columns>
-          </Box>
-        </Stack>
-      </Card>
-    </Box>
-  )
-}
-LeakingExample.story = {
-  name: 'leaking example',
 }

--- a/src/components/Inline/__tests__/useAlignment.js
+++ b/src/components/Inline/__tests__/useAlignment.js
@@ -6,15 +6,13 @@ describe('useAlignment', () => {
     const alignBottom = useAlignment('bottom')
     const alignCenter = useAlignment('center')
 
-    expect(alignTop).toEqual({ alignItems: 'flex-start' })
-    expect(alignBottom).toEqual({ alignItems: 'flex-end' })
-    expect(alignCenter).toEqual({ alignItems: 'center' })
+    expect(alignTop).toEqual('flex-start')
+    expect(alignBottom).toEqual('flex-end')
+    expect(alignCenter).toEqual('center')
   })
 
   test('when you pass a responsive array you should get out an array', () => {
     const responsiveAlignment = useAlignment(['top', 'bottom', 'center'])
-    expect(responsiveAlignment).toEqual({
-      alignItems: ['flex-start', 'flex-end', 'center'],
-    })
+    expect(responsiveAlignment).toEqual(['flex-start', 'flex-end', 'center'])
   })
 })

--- a/src/components/Inline/index.jsx
+++ b/src/components/Inline/index.jsx
@@ -3,51 +3,27 @@
  *
  * Note: Currently, it's not possible to use <Hidden> inside an <Inline>. This needs more work, but I'm not sure if we will actually need it...
  */
-import React, { Children } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
-import flattenChildren from 'react-keyed-flatten-children'
 
 import { propType } from '../../util/style'
 import Box from '../Box'
-import Flex from '../Flex'
-import useNegativeValue from '../private/hooks/useNegativeValue'
 
 import useFlexDirection from './useFlexDirection'
 import useAlignment from './useAlignment'
 
 const Inline = ({ space, collapseBelow, alignY, children }) => {
-  const inlineItems = flattenChildren(children)
-
   return (
     <Box
       sx={{
-        'position': 'static',
-        '&::before': {
-          content: '""',
-          display: 'table',
-          mt: useNegativeValue(space),
-        },
+        display: 'inline-flex',
+        flexWrap: 'wrap',
+        flexDirection: useFlexDirection(collapseBelow),
+        alignItems: useAlignment(alignY),
+        gap: space,
       }}
     >
-      <Flex
-        flexWrap="wrap"
-        flexDirection={useFlexDirection(collapseBelow)}
-        {...useAlignment(alignY)}
-        sx={{
-          'position': 'static',
-          '&::before': {
-            content: '""',
-            display: 'table',
-            ml: useNegativeValue(space),
-          },
-        }}
-      >
-        {Children.map(inlineItems, child => {
-          return (
-            <Box sx={{ pl: space, pt: space, position: 'static' }}>{child}</Box>
-          )
-        })}
-      </Flex>
+      {children}
     </Box>
   )
 }
@@ -67,6 +43,7 @@ Inline.propTypes = {
   space: propType,
   /** Shows components in a single column below this breakpoint */
   collapseBelow: PropTypes.oneOf(['mobile', 'tablet', 'desktop']),
+  /** Vertical alignment of components */
   alignY: PropTypes.oneOfType([alignYValues, PropTypes.arrayOf(alignYValues)]),
 }
 

--- a/src/components/Inline/index.stories.jsx
+++ b/src/components/Inline/index.stories.jsx
@@ -1,9 +1,7 @@
 /* eslint-disable no-alert */
 import React from 'react'
-import { boolean, select } from '@storybook/addon-knobs'
+import { select } from '@storybook/addon-knobs'
 
-import Box from '../Box'
-import Button from '../Button'
 import Placeholder from '../private/Placeholder'
 
 import Inline from './index'
@@ -81,64 +79,4 @@ export const AlignY = () => {
 }
 AlignY.story = {
   name: 'vertically aligned',
-}
-
-export const Adjacent = () => {
-  const space = select('Space', ALL_SPACES, 5)
-
-  return (
-    <Box css={{ display: 'flex', flexDirection: 'row' }}>
-      <Inline>
-        <Button onClick={() => alert('Yes i am!')}>Am I clickable?</Button>
-      </Inline>
-      <Inline space={space}>
-        <Placeholder width={50} height={50} />
-        <Placeholder width={50} height={50} />
-        <Placeholder width={50} height={50} />
-      </Inline>
-    </Box>
-  )
-}
-Adjacent.story = {
-  name: 'with adjacent interactive elements',
-}
-
-export const LeakingExample = () => {
-  const space = select('Space', ALL_SPACES, 7)
-  const withIndex = boolean('Using z-index', true)
-
-  return (
-    <Box
-      css={{
-        display: 'flex',
-        flexDirection: 'row',
-      }}
-    >
-      <Box
-        sx={{
-          zIndex: withIndex ? '2' : null,
-        }}
-      >
-        <Inline>
-          <Button onClick={() => alert('Yes i am!')}>
-            Am I clickable? Try with high space values
-          </Button>
-        </Inline>
-      </Box>
-      <Box
-        sx={{
-          zIndex: withIndex ? '1' : null,
-        }}
-      >
-        <Inline space={space}>
-          <Placeholder width={50} height={50} />
-          <Placeholder width={50} height={50} />
-          <Placeholder width={50} height={50} />
-        </Inline>
-      </Box>
-    </Box>
-  )
-}
-LeakingExample.story = {
-  name: 'leaking example',
 }

--- a/src/components/Inline/useAlignment.js
+++ b/src/components/Inline/useAlignment.js
@@ -17,19 +17,11 @@ const transformAlign = direction => {
   return alignment
 }
 
-const getValues = values => {
+const useAlignment = values => {
   if (Array.isArray(values)) {
     return values.map(a => transformAlign(a))
   }
   return transformAlign(values)
-}
-
-const useAlignment = x => {
-  const alignment = getValues(x)
-
-  return {
-    alignItems: alignment,
-  }
 }
 
 export default useAlignment

--- a/src/components/Stack/index.jsx
+++ b/src/components/Stack/index.jsx
@@ -7,10 +7,8 @@ import flattenChildren from 'react-keyed-flatten-children'
 
 import { propType } from '../../util/style'
 import Box from '../Box'
-import useNegativeValue from '../private/hooks/useNegativeValue'
 
-const useStackItem = ({ align, space }) => ({
-  pt: space,
+const useStackItem = ({ align }) => ({
   width: '100%',
   // If we're aligned left across all screen sizes,
   // there's actually no alignment work to do.
@@ -29,27 +27,20 @@ const Stack = ({ as, space, children, align }) => {
   // when the stack should be a list we need to render `<li>`s
   const isList = as === 'ol' || as === 'ul'
   const stackItemComponent = isList ? 'li' : 'div'
-  const stackItemProps = useStackItem({ space, align })
+  const stackItemStyles = useStackItem({ align })
 
   return (
     <Box
       as={as}
       sx={{
-        'position': 'static',
-        '&::before': {
-          content: '""',
-          display: 'table',
-          mt: useNegativeValue(space),
-        },
+        display: 'flex',
+        flexDirection: 'column',
+        gap: space,
       }}
     >
       {Children.map(stackItems, child => {
         return (
-          <Box
-            as={stackItemComponent}
-            {...stackItemProps}
-            sx={{ position: 'static' }}
-          >
+          <Box as={stackItemComponent} sx={{ ...stackItemStyles }}>
             {child}
           </Box>
         )

--- a/src/components/Stack/index.stories.jsx
+++ b/src/components/Stack/index.stories.jsx
@@ -1,13 +1,8 @@
 /* eslint-disable no-alert */
 import React from 'react'
-import { select, boolean } from '@storybook/addon-knobs'
+import { select } from '@storybook/addon-knobs'
 
-import Box from '../Box'
-import Button from '../Button'
-import Inline from '../Inline'
 import Placeholder from '../private/Placeholder'
-import Flex from '../Flex'
-import Text from '../Text'
 
 import Stack from './index'
 
@@ -30,60 +25,4 @@ export const Default = () => {
 }
 Default.story = {
   name: 'default',
-}
-
-export const Adjacent = () => {
-  const space = select('Space', ALL_SPACES, 3)
-
-  return (
-    <Box>
-      <Inline>
-        <Button onClick={() => alert('I am!')}>Am I clickable?</Button>
-      </Inline>
-      <Stack space={space}>
-        <Placeholder height={50} width="100%" />
-        <Placeholder height={50} width="100%" />
-        <Placeholder height={50} width="100%" />
-      </Stack>
-    </Box>
-  )
-}
-Adjacent.story = {
-  name: 'with adjacent interactive elements',
-}
-
-export const LeakingExample = () => {
-  const space = select('Space', ALL_SPACES, 6)
-  const withIndex = boolean('Using z-index', true)
-
-  return (
-    <Box sx={{ border: 'solid 3px black' }}>
-      <Text>Check the README for an explanation</Text>
-      <Flex
-        sx={{
-          zIndex: withIndex ? '2' : null,
-        }}
-      >
-        <Inline>
-          <Button onClick={() => alert('Yes, I am!')}>
-            But am I clickable? Try me with and without z-index and a space
-            value above 4
-          </Button>
-        </Inline>
-      </Flex>
-      <Box sx={{ zIndex: withIndex ? '1' : null, border: 'solid 3px red' }}>
-        <Stack space={space}>
-          <Inline>
-            <Button onClick={() => alert('I am!')}>Am I clickable?</Button>
-          </Inline>
-          <Placeholder height={50} width="100%" />
-          <Placeholder height={50} width="100%" />
-          <Placeholder height={50} width="100%" />
-        </Stack>
-      </Box>
-    </Box>
-  )
-}
-LeakingExample.story = {
-  name: 'leaking example',
 }

--- a/src/components/Tiles/__tests__/useAlignment.js
+++ b/src/components/Tiles/__tests__/useAlignment.js
@@ -2,17 +2,16 @@ import useAlignment from '../useAlignment'
 
 describe('useAlignment', () => {
   test('when you pass a single value you get the expected styles', () => {
-    const alignRight = useAlignment('right')
-    const alignLeft = useAlignment('left')
-    const alignCenter = useAlignment('center')
-
-    expect(alignRight).toEqual('flex-end')
-    expect(alignLeft).toEqual('flex-start')
-    expect(alignCenter).toEqual('center')
+    expect(useAlignment('right')).toEqual('flex-end')
+    expect(useAlignment('left')).toEqual('flex-start')
+    expect(useAlignment('center')).toEqual('center')
   })
 
   test('when you pass a responsive array you should get out an array', () => {
-    const responsiveAlignment = useAlignment(['right', 'left', 'center'])
-    expect(responsiveAlignment).toEqual(['flex-end', 'flex-start', 'center'])
+    expect(useAlignment(['right', 'left', 'center'])).toEqual([
+      'flex-end',
+      'flex-start',
+      'center',
+    ])
   })
 })

--- a/src/components/Tiles/__tests__/useColumns.js
+++ b/src/components/Tiles/__tests__/useColumns.js
@@ -2,17 +2,16 @@ import useColumns from '../useColumns'
 
 describe('useColumns', () => {
   test('when you pass a number you get the expected styles', () => {
-    const flexColsTwo = useColumns(2)
-    const flexColsFour = useColumns(4)
-    const flexColsHundred = useColumns(100)
-
-    expect(flexColsTwo).toEqual('0 0 50%')
-    expect(flexColsFour).toEqual('0 0 25%')
-    expect(flexColsHundred).toEqual('0 0 1%')
+    expect(useColumns(2)).toEqual('repeat(2, 1fr)')
+    expect(useColumns(4)).toEqual('repeat(4, 1fr)')
+    expect(useColumns(10)).toEqual('repeat(10, 1fr)')
   })
 
   test('when you pass in responsive cols you should get out responsive flex width', () => {
-    const responsiveFlexCols = useColumns([2, 4, 1])
-    expect(responsiveFlexCols).toEqual(['0 0 50%', '0 0 25%', '0 0 100%'])
+    expect(useColumns([2, 4, 1])).toEqual([
+      'repeat(2, 1fr)',
+      'repeat(4, 1fr)',
+      'repeat(1, 1fr)',
+    ])
   })
 })

--- a/src/components/Tiles/index.jsx
+++ b/src/components/Tiles/index.jsx
@@ -6,58 +6,31 @@ import flattenChildren from 'react-keyed-flatten-children'
 
 import { propType } from '../../util/style'
 import Box from '../Box'
-import useNegativeValue from '../private/hooks/useNegativeValue'
+import Flex from '../Flex'
 
-import useColumns from './useColumns'
 import useAlignment from './useAlignment'
+import useColumns from './useColumns'
 
 const Tiles = ({ columns, as, space, align, children }) => (
   <Box
     as={as}
     sx={{
-      display: 'block',
+      display: 'grid',
       width: '100%',
-      position: 'static',
-      mt: useNegativeValue(space),
+      gridGap: space,
+      gridTemplateColumns: useColumns(columns),
     }}
   >
-    <Box
-      sx={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: useAlignment(align),
-        position: 'static',
-        ml: useNegativeValue(space),
-      }}
-    >
-      {Children.map(flattenChildren(children), child => (
-        <Box
-          sx={{
-            'minWidth': 0,
-            'flex': useColumns(columns),
-            'position': 'static',
-            '@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none)':
-              {
-                // IE11 needs this overflow, although it doesn't change the layout.
-                // Without it, IE11 creates horizontal scrollbars.
-                overflow: 'hidden',
-              },
-          }}
-        >
-          <Box
-            sx={{
-              height: '100%',
-              position: 'static',
-              /* This needs to be a separate element to support IE11. */
-              paddingTop: space,
-              paddingLeft: space,
-            }}
-          >
-            {child}
-          </Box>
-        </Box>
-      ))}
-    </Box>
+    {Children.map(flattenChildren(children), child => (
+      <Flex
+        sx={{
+          minWidth: 0,
+          justifyContent: useAlignment(align),
+        }}
+      >
+        {child}
+      </Flex>
+    ))}
   </Box>
 )
 

--- a/src/components/Tiles/index.stories.jsx
+++ b/src/components/Tiles/index.stories.jsx
@@ -1,10 +1,8 @@
 /* eslint-disable no-alert */
 import React from 'react'
-import { text, select, boolean } from '@storybook/addon-knobs'
+import { text, select } from '@storybook/addon-knobs'
 
 import Placeholder from '../private/Placeholder'
-import Box from '../Box'
-import Button from '../Button'
 
 import Tiles from './index'
 
@@ -17,18 +15,19 @@ export const Default = () => {
   const as = text('as', 'div')
   const columns = select('Columns', [1, 2, 3, 4], 3)
   const space = select('Space', ALL_SPACES, 5)
+  const align = select('Align', ['left', 'right', 'center'], 'center')
 
   return (
-    <Tiles columns={columns} as={as} space={space}>
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
+    <Tiles columns={columns} as={as} space={space} align={align}>
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="50%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
     </Tiles>
   )
 }
@@ -36,71 +35,28 @@ Default.story = {
   name: 'default',
 }
 
-export const Adjacent = () => {
+export const ResponsiveColumns = () => {
   const as = text('as', 'div')
-  const columns = select('Columns', [1, 2, 3, 4], 3)
-  const space = select('Space', ALL_SPACES, 5)
 
   return (
-    <Box>
-      <Box>
-        <Button onClick={() => alert('Yes I am!')}>Am I clickable?</Button>
-      </Box>
-      <Tiles columns={columns} as={as} space={space}>
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-      </Tiles>
-    </Box>
+    <Tiles
+      columns={[2, 1, 3]}
+      as={as}
+      space={[2, 3, 5]}
+      align={['right', 'left', 'center']}
+    >
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="50%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="80%" />
+      <Placeholder height={50} width="100%" />
+    </Tiles>
   )
 }
-Adjacent.story = {
-  name: 'with adjacent interactive elements',
-}
-
-export const LeakingExample = () => {
-  const as = text('as', 'div')
-  const columns = select('Columns', [1, 2, 3, 4], 3)
-  const space = select('Space', ALL_SPACES, 6)
-  const withIndex = boolean('Using z-index', true)
-
-  return (
-    <Box>
-      <Box
-        sx={{
-          zIndex: withIndex ? '2' : null,
-        }}
-      >
-        <Button onClick={() => alert('Yes I am!')}>
-          Am I clickable? Try with high space values
-        </Button>
-      </Box>
-      <Box
-        sx={{
-          zIndex: withIndex ? '1' : null,
-        }}
-      >
-        <Tiles columns={columns} as={as} space={space}>
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-        </Tiles>
-      </Box>
-    </Box>
-  )
-}
-LeakingExample.story = {
-  name: 'leaking example',
+ResponsiveColumns.story = {
+  name: 'with responsive column count',
 }

--- a/src/components/Tiles/useColumns.js
+++ b/src/components/Tiles/useColumns.js
@@ -1,13 +1,10 @@
-const getColWidth = cols => {
-  return `${100 / cols}%` || `100%`
-}
-
-const useColumns = cols => {
+const useColumns = columnCount => {
   // if we have an array must be responsive
-  if (Array.isArray(cols)) {
-    return cols.map(bpCols => `0 0 ${getColWidth(bpCols)}`)
+  if (Array.isArray(columnCount)) {
+    return columnCount.map(col => `repeat(${col}, 1fr)`)
   }
-  return `0 0 ${getColWidth(cols)}`
+
+  return `repeat(${columnCount}, 1fr)`
 }
 
 export default useColumns


### PR DESCRIPTION
# What 
We decided it's time to drop IE11 support for our layout components in
favor of using flexbox's `gap` property. Previously, we tried to avoid
`gap` (because [it's not supported by IE11](https://caniuse.com/flexbox-gap)) but this has led to some
gnarly issues with negative margins (see #279, #276, #270).

# Affected components (check if merged into this branch)
- [x] `Stack` (#296)
- [x] `Inline` (#292)
- [x] `Tiles` (#295 )
- [x] `Columns` (#294)

# To do
- [x] Add changeset with major release notes