### PR TITLE
Drop IE11 for `Columns` in favor of flexbox's `gap`

### DIFF
--- a/src/components/Column/index.jsx
+++ b/src/components/Column/index.jsx
@@ -10,7 +10,7 @@ const resolveWidth = {
 }
 
 const Column = ({ width, children }) => {
-  const { pt, pl, defaultWidth } = useContext(ColumnsContext)
+  const { defaultWidth } = useContext(ColumnsContext)
 
   // If width is `auto`, we need to make sure the column doesn't break lines
   const preventBreak = width === 'auto'
@@ -18,11 +18,8 @@ const Column = ({ width, children }) => {
   return (
     <Box
       sx={{
-        pt,
-        pl,
         width: resolveWidth[width] ?? width ?? defaultWidth,
         flexShrink: preventBreak ? 0 : null,
-        position: 'static',
       }}
     >
       {children}

--- a/src/components/Column/index.stories.jsx
+++ b/src/components/Column/index.stories.jsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { text, select } from '@storybook/addon-knobs'
 
-import Box from '../Box'
-import Button from '../Button'
 import Columns from '../Columns'
 import Placeholder from '../private/Placeholder'
 
@@ -74,33 +72,4 @@ export const AutoWidth = () => (
 )
 AutoWidth.story = {
   name: 'automatic width',
-}
-
-export const Adjacent = () => {
-  const space = select('Space', ALL_SPACES, 5)
-
-  return (
-    <Box sx={{ display: 'flex' }}>
-      <Box>
-        <Button>Am I clickable?</Button>
-      </Box>
-      <Columns space={space}>
-        <Column>
-          <Placeholder height={50} width="100%" label="hello there" />
-        </Column>
-        <Column>
-          <Placeholder height={50} width="100%" label="hello there" />
-        </Column>
-        <Column>
-          <Placeholder height={50} width="100%" label="hello there" />
-        </Column>
-        <Column>
-          <Placeholder height={50} width="100%" label="hello there" />
-        </Column>
-      </Columns>
-    </Box>
-  )
-}
-Adjacent.story = {
-  name: 'with adjacent interactive elements',
 }

--- a/src/components/Columns/index.jsx
+++ b/src/components/Columns/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 
 import { propTypes } from '../../util/style'
 import Flex from '../Flex'
-import useNegativeValue from '../private/hooks/useNegativeValue'
 
 import useDefaultWidth from './useDefaultWidth'
 import useFlexAlignment from './useFlexAlignment'
@@ -16,23 +15,6 @@ export const ColumnsContext = createContext({
   defaultWidth: '100%',
 })
 
-// -----
-// align: 'center' | 'right' | 'left' || Array < 'center' | 'right' | 'left' >
-//   How children will align top to bottom, can also be an array of how the children will align
-//   at breakpoints
-// -----
-// alignY: 'center' | 'top' | 'bottom' || Array<'center' | 'top' | 'bottom'>
-//   How children will align along you y axis so top to bottom, can also be an array for
-//   responsive props
-// -----
-// collapseBellow:? 'mobile' | 'tablet' | 'desktop'
-//   At what breakpoint would you like to collapse into cols mode, this is most of the time
-//   just mobile, but if you want to keep a row just don't supply anything here
-// -----
-// space:?propTypes.space
-//   Optional prop for how to space out the children also can be responsive array
-// -----
-
 const Columns = ({ children, collapseBelow, space, alignY, align }) => {
   // calculate the default width to use if none if provided for the children
   // add it to the context so each col can just use the default width per item
@@ -41,19 +23,15 @@ const Columns = ({ children, collapseBelow, space, alignY, align }) => {
 
   return (
     <Flex
-      {...useFlexAlignment(align, alignY, collapseBelow)}
-      flexDirection={useFlexDirection(collapseBelow)}
-      flexWrap={useFlexWrap(collapseBelow)}
       sx={{
-        position: 'static',
-        mt: useNegativeValue(space),
-        ml: useNegativeValue(space),
+        flexWrap: useFlexWrap(collapseBelow),
+        flexDirection: useFlexDirection(collapseBelow),
+        ...useFlexAlignment(align, alignY, collapseBelow),
+        gap: space,
       }}
     >
       <ColumnsContext.Provider
         value={{
-          pl: space,
-          pt: space,
           defaultWidth,
         }}
       >
@@ -69,7 +47,6 @@ Columns.defaultProps = {
   alignY: 'top',
 }
 
-// enums for prop checking
 const alignValues = PropTypes.oneOf(['left', 'right', 'center', 'fill'])
 const alignYValues = PropTypes.oneOf(['top', 'bottom', 'center', 'stretch'])
 
@@ -78,9 +55,13 @@ Columns.propTypes = {
     PropTypes.arrayOf(PropTypes.element),
     PropTypes.element,
   ]).isRequired,
+  /** Breakpoint for when columns should appear stacked vertically */
   collapseBelow: PropTypes.oneOf(['mobile', 'tablet', 'desktop']),
+  /** Spacing between child components */
   ...propTypes.space,
+  /** Vertical alignment of child components */
   alignY: PropTypes.oneOfType([alignYValues, PropTypes.arrayOf(alignYValues)]),
+  /** Horizontal alignment of child components */
   align: PropTypes.oneOfType([alignValues, PropTypes.arrayOf(alignValues)]),
 }
 

--- a/src/components/Columns/index.stories.jsx
+++ b/src/components/Columns/index.stories.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import { select, number, array, text, boolean } from '@storybook/addon-knobs'
+import { select, number, array, text } from '@storybook/addon-knobs'
 
 import Column from '../Column'
 import Box from '../Box'
-import Inline from '../Inline'
 import Text from '../Text'
 import Card from '../Card'
 import Button from '../Button'
@@ -172,55 +171,4 @@ export const ExampleWithButton = () => {
 }
 ExampleWithButton.story = {
   name: 'example with Button',
-}
-
-// All possible values for `space` according to our theme
-const ALL_SPACES = [0, 1, 2, 3, 4, 5, 6, 7, 8]
-
-export const LeakingExample = () => {
-  const space = select('Space', ALL_SPACES, 6)
-  const withIndex = boolean('Using z-index', true)
-
-  // eslint-disable-next-line no-alert
-  const click = () => alert('Yes I am!')
-
-  return (
-    <Box>
-      <Card>
-        <Stack space={3}>
-          <Box
-            sx={{
-              zIndex: withIndex ? '2' : null,
-            }}
-          >
-            <Inline>
-              <Button onClick={click}>
-                Am I clickable? Try with high space values
-              </Button>
-            </Inline>
-          </Box>
-          <Box
-            sx={{
-              zIndex: withIndex ? '1' : null,
-            }}
-          >
-            <Columns space={space} collapseBelow="mobile">
-              <Column width="fill">
-                <Text>
-                  Your comments over the report had been uploaded. We will
-                  upload the final report shortly.
-                </Text>
-              </Column>
-              <Column width="auto">
-                <Button>Continue</Button>
-              </Column>
-            </Columns>
-          </Box>
-        </Stack>
-      </Card>
-    </Box>
-  )
-}
-LeakingExample.story = {
-  name: 'leaking example',
 }


### PR DESCRIPTION
We decided it's time to drop IE11 support for our `Columns` component in
favor of using `flexbox`'s `gap` property. Previously, we tried to avoid
`gap` (because it's not supported by IE11) but this has lead to some
gnarly issues with negative margins.