### PR TITLE
Drop IE11 for `Tiles` in favor of flexbox's `gap`

### DIFF
--- a/src/components/Tiles/__tests__/useAlignment.js
+++ b/src/components/Tiles/__tests__/useAlignment.js
@@ -2,17 +2,16 @@ import useAlignment from '../useAlignment'
 
 describe('useAlignment', () => {
   test('when you pass a single value you get the expected styles', () => {
-    const alignRight = useAlignment('right')
-    const alignLeft = useAlignment('left')
-    const alignCenter = useAlignment('center')
-
-    expect(alignRight).toEqual('flex-end')
-    expect(alignLeft).toEqual('flex-start')
-    expect(alignCenter).toEqual('center')
+    expect(useAlignment('right')).toEqual('flex-end')
+    expect(useAlignment('left')).toEqual('flex-start')
+    expect(useAlignment('center')).toEqual('center')
   })
 
   test('when you pass a responsive array you should get out an array', () => {
-    const responsiveAlignment = useAlignment(['right', 'left', 'center'])
-    expect(responsiveAlignment).toEqual(['flex-end', 'flex-start', 'center'])
+    expect(useAlignment(['right', 'left', 'center'])).toEqual([
+      'flex-end',
+      'flex-start',
+      'center',
+    ])
   })
 })

--- a/src/components/Tiles/__tests__/useColumns.js
+++ b/src/components/Tiles/__tests__/useColumns.js
@@ -2,17 +2,16 @@ import useColumns from '../useColumns'
 
 describe('useColumns', () => {
   test('when you pass a number you get the expected styles', () => {
-    const flexColsTwo = useColumns(2)
-    const flexColsFour = useColumns(4)
-    const flexColsHundred = useColumns(100)
-
-    expect(flexColsTwo).toEqual('0 0 50%')
-    expect(flexColsFour).toEqual('0 0 25%')
-    expect(flexColsHundred).toEqual('0 0 1%')
+    expect(useColumns(2)).toEqual('repeat(2, 1fr)')
+    expect(useColumns(4)).toEqual('repeat(4, 1fr)')
+    expect(useColumns(10)).toEqual('repeat(10, 1fr)')
   })
 
   test('when you pass in responsive cols you should get out responsive flex width', () => {
-    const responsiveFlexCols = useColumns([2, 4, 1])
-    expect(responsiveFlexCols).toEqual(['0 0 50%', '0 0 25%', '0 0 100%'])
+    expect(useColumns([2, 4, 1])).toEqual([
+      'repeat(2, 1fr)',
+      'repeat(4, 1fr)',
+      'repeat(1, 1fr)',
+    ])
   })
 })

--- a/src/components/Tiles/index.jsx
+++ b/src/components/Tiles/index.jsx
@@ -6,58 +6,31 @@ import flattenChildren from 'react-keyed-flatten-children'
 
 import { propType } from '../../util/style'
 import Box from '../Box'
-import useNegativeValue from '../private/hooks/useNegativeValue'
+import Flex from '../Flex'
 
-import useColumns from './useColumns'
 import useAlignment from './useAlignment'
+import useColumns from './useColumns'
 
 const Tiles = ({ columns, as, space, align, children }) => (
   <Box
     as={as}
     sx={{
-      display: 'block',
+      display: 'grid',
       width: '100%',
-      position: 'static',
-      mt: useNegativeValue(space),
+      gridGap: space,
+      gridTemplateColumns: useColumns(columns),
     }}
   >
-    <Box
-      sx={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        justifyContent: useAlignment(align),
-        position: 'static',
-        ml: useNegativeValue(space),
-      }}
-    >
-      {Children.map(flattenChildren(children), child => (
-        <Box
-          sx={{
-            'minWidth': 0,
-            'flex': useColumns(columns),
-            'position': 'static',
-            '@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none)':
-              {
-                // IE11 needs this overflow, although it doesn't change the layout.
-                // Without it, IE11 creates horizontal scrollbars.
-                overflow: 'hidden',
-              },
-          }}
-        >
-          <Box
-            sx={{
-              height: '100%',
-              position: 'static',
-              /* This needs to be a separate element to support IE11. */
-              paddingTop: space,
-              paddingLeft: space,
-            }}
-          >
-            {child}
-          </Box>
-        </Box>
-      ))}
-    </Box>
+    {Children.map(flattenChildren(children), child => (
+      <Flex
+        sx={{
+          minWidth: 0,
+          justifyContent: useAlignment(align),
+        }}
+      >
+        {child}
+      </Flex>
+    ))}
   </Box>
 )
 

--- a/src/components/Tiles/index.stories.jsx
+++ b/src/components/Tiles/index.stories.jsx
@@ -1,10 +1,8 @@
 /* eslint-disable no-alert */
 import React from 'react'
-import { text, select, boolean } from '@storybook/addon-knobs'
+import { text, select } from '@storybook/addon-knobs'
 
 import Placeholder from '../private/Placeholder'
-import Box from '../Box'
-import Button from '../Button'
 
 import Tiles from './index'
 
@@ -17,18 +15,19 @@ export const Default = () => {
   const as = text('as', 'div')
   const columns = select('Columns', [1, 2, 3, 4], 3)
   const space = select('Space', ALL_SPACES, 5)
+  const align = select('Align', ['left', 'right', 'center'], 'center')
 
   return (
-    <Tiles columns={columns} as={as} space={space}>
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
-      <Placeholder height={50} />
+    <Tiles columns={columns} as={as} space={space} align={align}>
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="50%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
     </Tiles>
   )
 }
@@ -36,71 +35,28 @@ Default.story = {
   name: 'default',
 }
 
-export const Adjacent = () => {
+export const ResponsiveColumns = () => {
   const as = text('as', 'div')
-  const columns = select('Columns', [1, 2, 3, 4], 3)
-  const space = select('Space', ALL_SPACES, 5)
 
   return (
-    <Box>
-      <Box>
-        <Button onClick={() => alert('Yes I am!')}>Am I clickable?</Button>
-      </Box>
-      <Tiles columns={columns} as={as} space={space}>
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-        <Placeholder height={50} />
-      </Tiles>
-    </Box>
+    <Tiles
+      columns={[2, 1, 3]}
+      as={as}
+      space={[2, 3, 5]}
+      align={['right', 'left', 'center']}
+    >
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="50%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="100%" />
+      <Placeholder height={50} width="80%" />
+      <Placeholder height={50} width="100%" />
+    </Tiles>
   )
 }
-Adjacent.story = {
-  name: 'with adjacent interactive elements',
-}
-
-export const LeakingExample = () => {
-  const as = text('as', 'div')
-  const columns = select('Columns', [1, 2, 3, 4], 3)
-  const space = select('Space', ALL_SPACES, 6)
-  const withIndex = boolean('Using z-index', true)
-
-  return (
-    <Box>
-      <Box
-        sx={{
-          zIndex: withIndex ? '2' : null,
-        }}
-      >
-        <Button onClick={() => alert('Yes I am!')}>
-          Am I clickable? Try with high space values
-        </Button>
-      </Box>
-      <Box
-        sx={{
-          zIndex: withIndex ? '1' : null,
-        }}
-      >
-        <Tiles columns={columns} as={as} space={space}>
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-          <Placeholder height={50} />
-        </Tiles>
-      </Box>
-    </Box>
-  )
-}
-LeakingExample.story = {
-  name: 'leaking example',
+ResponsiveColumns.story = {
+  name: 'with responsive column count',
 }

--- a/src/components/Tiles/useColumns.js
+++ b/src/components/Tiles/useColumns.js
@@ -1,13 +1,10 @@
-const getColWidth = cols => {
-  return `${100 / cols}%` || `100%`
-}
-
-const useColumns = cols => {
+const useColumns = columnCount => {
   // if we have an array must be responsive
-  if (Array.isArray(cols)) {
-    return cols.map(bpCols => `0 0 ${getColWidth(bpCols)}`)
+  if (Array.isArray(columnCount)) {
+    return columnCount.map(col => `repeat(${col}, 1fr)`)
   }
-  return `0 0 ${getColWidth(cols)}`
+
+  return `repeat(${columnCount}, 1fr)`
 }
 
 export default useColumns


### PR DESCRIPTION
We decided it's time to drop IE11 support for our `Tiles` component in
favor of using `flexbox`'s `gap` property. Previously, we tried to avoid
`gap` (because it's not supported by IE11) but this has lead to some
gnarly issues with negative margins.