### PR TITLE
Drop IE11 for `Stack` in favor of flexbox's `gap`

### DIFF
--- a/src/components/Stack/index.jsx
+++ b/src/components/Stack/index.jsx
@@ -7,10 +7,8 @@ import flattenChildren from 'react-keyed-flatten-children'
 
 import { propType } from '../../util/style'
 import Box from '../Box'
-import useNegativeValue from '../private/hooks/useNegativeValue'
 
-const useStackItem = ({ align, space }) => ({
-  pt: space,
+const useStackItem = ({ align }) => ({
   width: '100%',
   // If we're aligned left across all screen sizes,
   // there's actually no alignment work to do.
@@ -29,27 +27,20 @@ const Stack = ({ as, space, children, align }) => {
   // when the stack should be a list we need to render `<li>`s
   const isList = as === 'ol' || as === 'ul'
   const stackItemComponent = isList ? 'li' : 'div'
-  const stackItemProps = useStackItem({ space, align })
+  const stackItemStyles = useStackItem({ align })
 
   return (
     <Box
       as={as}
       sx={{
-        'position': 'static',
-        '&::before': {
-          content: '""',
-          display: 'table',
-          mt: useNegativeValue(space),
-        },
+        display: 'flex',
+        flexDirection: 'column',
+        gap: space,
       }}
     >
       {Children.map(stackItems, child => {
         return (
-          <Box
-            as={stackItemComponent}
-            {...stackItemProps}
-            sx={{ position: 'static' }}
-          >
+          <Box as={stackItemComponent} sx={{ ...stackItemStyles }}>
             {child}
           </Box>
         )

--- a/src/components/Stack/index.stories.jsx
+++ b/src/components/Stack/index.stories.jsx
@@ -1,13 +1,8 @@
 /* eslint-disable no-alert */
 import React from 'react'
-import { select, boolean } from '@storybook/addon-knobs'
+import { select } from '@storybook/addon-knobs'
 
-import Box from '../Box'
-import Button from '../Button'
-import Inline from '../Inline'
 import Placeholder from '../private/Placeholder'
-import Flex from '../Flex'
-import Text from '../Text'
 
 import Stack from './index'
 
@@ -30,60 +25,4 @@ export const Default = () => {
 }
 Default.story = {
   name: 'default',
-}
-
-export const Adjacent = () => {
-  const space = select('Space', ALL_SPACES, 3)
-
-  return (
-    <Box>
-      <Inline>
-        <Button onClick={() => alert('I am!')}>Am I clickable?</Button>
-      </Inline>
-      <Stack space={space}>
-        <Placeholder height={50} width="100%" />
-        <Placeholder height={50} width="100%" />
-        <Placeholder height={50} width="100%" />
-      </Stack>
-    </Box>
-  )
-}
-Adjacent.story = {
-  name: 'with adjacent interactive elements',
-}
-
-export const LeakingExample = () => {
-  const space = select('Space', ALL_SPACES, 6)
-  const withIndex = boolean('Using z-index', true)
-
-  return (
-    <Box sx={{ border: 'solid 3px black' }}>
-      <Text>Check the README for an explanation</Text>
-      <Flex
-        sx={{
-          zIndex: withIndex ? '2' : null,
-        }}
-      >
-        <Inline>
-          <Button onClick={() => alert('Yes, I am!')}>
-            But am I clickable? Try me with and without z-index and a space
-            value above 4
-          </Button>
-        </Inline>
-      </Flex>
-      <Box sx={{ zIndex: withIndex ? '1' : null, border: 'solid 3px red' }}>
-        <Stack space={space}>
-          <Inline>
-            <Button onClick={() => alert('I am!')}>Am I clickable?</Button>
-          </Inline>
-          <Placeholder height={50} width="100%" />
-          <Placeholder height={50} width="100%" />
-          <Placeholder height={50} width="100%" />
-        </Stack>
-      </Box>
-    </Box>
-  )
-}
-LeakingExample.story = {
-  name: 'leaking example',
 }


### PR DESCRIPTION
We decided it's time to drop IE11 support for our `Stack` component in
favor of using `flexbox`'s `gap` property. Previously, we tried to avoid
`gap` (because it's not supported by IE11) but this has lead to some
gnarly issues with negative margins.