### PR TITLE
Fix `ProgressBar`'s proptypes

### DIFF
--- a/.changeset/polite-colts-sing.md
+++ b/.changeset/polite-colts-sing.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Fix `ProgressBar`'s proptypes

--- a/src/components/ProgressBar/index.jsx
+++ b/src/components/ProgressBar/index.jsx
@@ -89,10 +89,10 @@ export default function ProgressBar({ variant, size, value, color, bg, fg }) {
 ProgressBar.propTypes = {
   variant: PropTypes.oneOf(['indeterminate', 'determinate']),
   size: PropTypes.oneOf(['normal', 'small']),
-  value: PropTypes.number(),
+  value: PropTypes.number,
   color: PropTypes.oneOf(['primary', 'secondary']),
-  bg: PropTypes.string(),
-  fg: PropTypes.string(),
+  bg: PropTypes.string,
+  fg: PropTypes.string,
 }
 
 ProgressBar.defaultProps = {


### PR DESCRIPTION
Due to this typo, the story was never displayed in Storybook.
