### PR TITLE
Use working CodeSandbox template

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "node": "14",
-  "sandboxes": ["qf-design-system-okfou"]
+  "sandboxes": ["qualifyze-design-system-basic-i7mrg2"]
 }


### PR DESCRIPTION
The template replaced in this commit wasn't working properly because it
was missing a `<ThemeProvider>`. Consequently, this adds a new template
with a working setup: https://codesandbox.io/s/qualifyze-design-system-basic-i7mrg2?file=/src/App.js