### PR TITLE
LoadingSpinner: change default size to 48px and fix prop types

### DIFF
--- a/.changeset/dry-scissors-work.md
+++ b/.changeset/dry-scissors-work.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+LoadingSpinner: change default size to 48px and fix prop types

--- a/src/components/LoadingSpinner/index.jsx
+++ b/src/components/LoadingSpinner/index.jsx
@@ -80,10 +80,10 @@ export default function LoadingSpinner(props) {
 
 LoadingSpinner.propTypes = {
   variant: PropTypes.oneOf(['primary', 'secondary', 'light']),
-  size: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 }
 
 LoadingSpinner.defaultProps = {
   variant: 'primary',
-  size: 80,
+  size: 48,
 }

--- a/src/components/LoadingSpinner/index.stories.jsx
+++ b/src/components/LoadingSpinner/index.stories.jsx
@@ -11,11 +11,11 @@ const variants = ['primary', 'secondary', 'light']
 
 export const Default = () => {
   const variant = select('Variant', variants, 'primary')
-  const size = text('Size', '80px')
+  const size = text('Size', '48px')
   const storyBg = text('Background', 'white')
 
   return (
-    <Box bg={storyBg} p={3}>
+    <Box sx={{ bg: storyBg, p: 3 }}>
       <LoadingSpinner variant={variant} size={size} />
     </Box>
   )


### PR DESCRIPTION
Reduce the size of the loading spinner from 80px to 48px to have a more sensible default. Also fixed a typo in the prop types.