### PR TITLE
Modal should allow for more flexible markup

### DIFF
--- a/.changeset/dull-trees-rest.md
+++ b/.changeset/dull-trees-rest.md
@@ -1,0 +1,10 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Modal should allow for more flexible markup
+
+We noticed that having a `form` in a modal breaks the parent-child
+relationship needed to make the flexbox layout work. This patch should(tm)
+fix the false assumption that `Modal.Body` is always a direct descendant
+of `Modal`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qualifyze/design-system",
-  "version": "1.11.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qualifyze/design-system",
-      "version": "1.11.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": "10.1.1",

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -28,7 +28,16 @@ function useLeftPadding() {
 // eslint-disable-next-line react/prop-types
 function Heading({ children, id }) {
   return (
-    <Box sx={{ pl: useLeftPadding(), pr: 3, pt: 3, pb: 3, mr: '44px' }}>
+    <Box
+      className="modal-internals"
+      sx={{
+        pl: useLeftPadding(),
+        pr: 3,
+        pt: 3,
+        pb: 3,
+        mr: '44px',
+      }}
+    >
       <BaseHeading as="span" level={4} weight="weak" id={id}>
         {children}
       </BaseHeading>
@@ -65,7 +74,14 @@ function Body(props) {
 // eslint-disable-next-line react/prop-types
 function Actions({ children }) {
   return (
-    <Box sx={{ py: 3, pl: useLeftPadding(), pr: 3 }}>
+    <Box
+      className="modal-internals"
+      sx={{
+        py: 3,
+        pl: useLeftPadding(),
+        pr: 3,
+      }}
+    >
       <BaseActions>{children}</BaseActions>
     </Box>
   )
@@ -77,11 +93,11 @@ const DialogContent = styled(BaseDialogContent, {
   shouldForwardProp: prop => prop !== 'maxWidth' && prop !== 'asSidebar',
 })(({ theme, asSidebar, maxWidth }) => ({
   '&[data-reach-dialog-content]': {
-    padding: 0,
-    background: 'white',
-    display: 'flex',
-    flexDirection: 'column',
-    width: '100%',
+    'padding': 0,
+    'background': 'white',
+    'display': 'flex',
+    'flexDirection': 'column',
+    'width': '100%',
     ...(asSidebar
       ? {
           right: 0,
@@ -109,6 +125,12 @@ const DialogContent = styled(BaseDialogContent, {
     },
     [`@media (min-width: ${theme.breakpoints.tablet})`]: {
       width: '50vw',
+    },
+    '& > *:not(.modal-internals)': {
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: '1',
+      overflowY: 'auto',
     },
   },
 }))

--- a/src/components/Modal/index.stories.jsx
+++ b/src/components/Modal/index.stories.jsx
@@ -10,6 +10,8 @@ import Inline from '../Inline'
 import SelectField from '../SelectField'
 import Stack from '../Stack'
 import Text from '../Text'
+import Heading from '../Heading'
+import TextField from '../TextField'
 
 import Modal from './index'
 
@@ -153,4 +155,123 @@ export const Bare = () => {
 }
 Bare.story = {
   name: 'bare Modal',
+}
+
+function simulateNetworkRequest() {
+  return new Promise(resolve => setTimeout(resolve, 2000))
+}
+
+export const WithForm = () => {
+  const [isModalOpen, setIsModalOpen] = React.useState(false)
+
+  return (
+    <>
+      <Box sx={{ p: 3 }}>
+        <Stack space={3}>
+          <Heading>Modal with form inside</Heading>
+          <Text>Open the modal below to see the form.</Text>
+          <Inline>
+            <Button onClick={() => setIsModalOpen(prev => !prev)}>
+              Open modal
+            </Button>
+          </Inline>
+        </Stack>
+      </Box>
+      <Modal isOpen={isModalOpen} onDismiss={() => setIsModalOpen(false)}>
+        <Formik
+          initialValues={{
+            firstName: '',
+            lastName: '',
+          }}
+          validationSchema={Yup.object().shape({
+            firstName: Yup.string().required('Please enter your first name'),
+            lastName: Yup.string().required('Please enter your last name'),
+          })}
+          onSubmit={values =>
+            simulateNetworkRequest().then(() => {
+              // eslint-disable-next-line no-alert
+              alert(JSON.stringify(values, null, 2))
+              setIsModalOpen(false)
+            })
+          }
+          validateOnSubmit
+          validateOnBlur={false}
+        >
+          {({ isSubmitting }) => (
+            <Form>
+              <Modal.Heading>This is a form</Modal.Heading>
+              <Modal.Body>
+                <Stack space={3}>
+                  <TextField name="firstName" label="First name" />
+                  <TextField name="lastName" label="Last name" />
+                  <Text>
+                    Veggies es bonus vobis, proinde vos postulo essum magis
+                    kohlrabi welsh onion daikon amaranth tatsoi tomatillo melon
+                    azuki bean garlic.
+                  </Text>
+
+                  <Text>
+                    Gumbo beet greens corn soko endive gumbo gourd. Parsley
+                    shallot courgette tatsoi pea sprouts fava bean collard
+                    greens dandelion okra wakame tomato. Dandelion cucumber
+                    earthnut pea peanut soko zucchini.
+                  </Text>
+
+                  <Text>
+                    Turnip greens yarrow ricebean rutabaga endive cauliflower
+                    sea lettuce kohlrabi amaranth water spinach avocado daikon
+                    napa cabbage asparagus winter purslane kale. Celery potato
+                    scallion desert raisin horseradish spinach carrot soko.
+                    Lotus root water spinach fennel kombu maize bamboo shoot
+                    green bean swiss chard seakale pumpkin onion chickpea gram
+                    corn pea. Brussels sprout coriander water chestnut gourd
+                    swiss chard wakame kohlrabi beetroot carrot watercress. Corn
+                    amaranth salsify bunya nuts nori azuki bean chickweed potato
+                    bell pepper artichoke.
+                  </Text>
+
+                  <Text>
+                    Nori grape silver beet broccoli kombu beet greens fava bean
+                    potato quandong celery. Bunya nuts black-eyed pea prairie
+                    turnip leek lentil turnip greens parsnip. Sea lettuce
+                    lettuce water chestnut eggplant winter purslane fennel azuki
+                    bean earthnut pea sierra leone bologi leek soko chicory
+                    celtuce parsley jÃ­cama salsify.
+                  </Text>
+
+                  <Text>
+                    Celery quandong swiss chard chicory earthnut pea potato.
+                    Salsify taro catsear garlic gram celery bitterleaf wattle
+                    seed collard greens nori. Grape wattle seed kombu beetroot
+                    horseradish carrot squash brussels sprout chard.
+                  </Text>
+
+                  <Text>
+                    Pea horseradish azuki bean lettuce avocado asparagus okra.
+                    Kohlrabi radish okra azuki bean corn fava bean mustard
+                    tigernut jÃ­cama green bean celtuce collard greens avocado
+                    quandong fennel gumbo black-eyed pea. Grape silver beet
+                    watercress potato tigernut corn groundnut. Chickweed okra
+                    pea winter purslane coriander yarrow sweet pepper radish
+                    garlic brussels sprout groundnut summer purslane earthnut
+                    pea tomato spring onion azuki bean gourd. Gumbo kakadu plum
+                    komatsuna black-eyed pea green bean zucchini gourd winter
+                    purslane silver beet rock melon radish asparagus spinach.
+                  </Text>
+                </Stack>
+              </Modal.Body>
+              <Modal.Actions>
+                <Button type="submit" isLoading={isSubmitting}>
+                  Submit
+                </Button>
+              </Modal.Actions>
+            </Form>
+          )}
+        </Formik>
+      </Modal>
+    </>
+  )
+}
+WithForm.story = {
+  name: 'with Form',
 }


### PR DESCRIPTION
We noticed that having a `form` in a modal breaks the parent-child
relationship needed to make the flexbox layout work. This should™ fix
the false assumption that `Modal.Body` is a direct descendant of
`Modal`.

