### PR TITLE
Add primary tone for `Icon`

### DIFF
--- a/.changeset/six-windows-add.md
+++ b/.changeset/six-windows-add.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': minor
+---
+
+Add primary tone for `Icon`.

--- a/src/components/Icon/index.jsx
+++ b/src/components/Icon/index.jsx
@@ -59,6 +59,9 @@ const SVG = styled('svg')(
       caution: {
         color: 'yellow.700',
       },
+      primary: {
+        color: 'primary.700',
+      },
       secondary: {
         color: 'grey.700',
       },
@@ -101,6 +104,7 @@ Icon.propTypes = {
     'neutral',
     'positive',
     'critical',
+    'primary',
     'secondary',
     'info',
     'caution',

--- a/src/components/Icon/index.stories.jsx
+++ b/src/components/Icon/index.stories.jsx
@@ -105,6 +105,7 @@ export const ColoredIcons = () => {
       'neutral',
       'positive',
       'critical',
+      'primary',
       'secondary',
       'info',
       'caution',


### PR DESCRIPTION
Needed for the lock icon according to Figma in Qualifyze/audit-ui#12