### PR TITLE
AppBar: adapt parent theme instead of overriding it

### DIFF
--- a/.changeset/spicy-jars-call.md
+++ b/.changeset/spicy-jars-call.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+AppBar: adapt parent theme instead of overriding it

--- a/src/components/AppBar/index.jsx
+++ b/src/components/AppBar/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Children, useMemo } from 'react'
 
-import { theme, ThemeProvider } from '../../util/style'
+import { ThemeProvider, useTheme } from '../../util/style'
 import Box from '../Box'
 import Hidden from '../Hidden'
 import Icon from '../Icon'
@@ -84,15 +84,21 @@ function selectElements(elements) {
 // We're already using the font sizes from Design System v2
 const v2fontSizes = ['12px', '14px', '16px', '18px']
 
-const themev2 = {
-  ...theme,
-  fontSizes: v2fontSizes,
+function useThemeV2() {
+  const baseTheme = useTheme()
+  return useMemo(
+    () => ({
+      ...baseTheme,
+      fontSizes: v2fontSizes,
+    }),
+    [baseTheme]
+  )
 }
-
 function AppBarContent({ position, children: elements }) {
   const { collapsed, toggleExpanded, expanded } = useAppBarContext()
   const { logo, primaryActions, secondaryActions, primaryNav, secondaryNav } =
     useMemo(() => selectElements(elements), [elements])
+  const themev2 = useThemeV2()
 
   return (
     <ThemeProvider theme={themev2}>

--- a/src/components/AppBar/index.stories.jsx
+++ b/src/components/AppBar/index.stories.jsx
@@ -1,12 +1,42 @@
 import { boolean, number, select } from '@storybook/addon-knobs'
-import React from 'react'
+import React, { useMemo } from 'react'
 
+import { theme as baseTheme, ThemeProvider } from '../../util/style'
 import Box from '../Box'
 import LoremIpsum from '../private/LoremIpsum'
 
 import AppBar from './index'
 
 export default { title: 'AppBar' }
+
+function useTheme(version) {
+  return useMemo(() => {
+    switch (version) {
+      case 'blue':
+        return baseTheme
+      case 'pink':
+        return {
+          ...baseTheme,
+          colors: {
+            ...baseTheme.colors,
+            primary: {
+              100: 'hsl(305, 84%, 94%)',
+              200: 'hsl(305, 84%, 77%)',
+              300: 'hsl(305, 84%, 62%)',
+              400: 'hsl(305, 84%, 48%)',
+              500: 'hsl(305, 84%, 36%)',
+              600: 'hsl(305, 84%, 30%)',
+              700: 'hsl(305, 84%, 24%)',
+              800: 'hsl(305, 84%, 19%)',
+              900: 'hsl(305, 84%, 14%)',
+            },
+          },
+        }
+      default:
+        throw new Error(`Invalid theme version: ${version}`)
+    }
+  }, [version])
+}
 
 export const Default = () => {
   const position = select(
@@ -27,8 +57,11 @@ export const Default = () => {
   const secondaryAction = boolean('secondary action', true)
   const secondaryNav = boolean('secondary nav item', true)
 
+  const themeVersion = select('theme', { blue: 'blue', pink: 'pink' }, 'blue')
+  const theme = useTheme(themeVersion)
+
   return (
-    <>
+    <ThemeProvider theme={theme}>
       <AppBar position={position} collapseBelow={collapseBelow}>
         <AppBar.Logo>Logo</AppBar.Logo>
         {numberOfNavItems > 0 && (
@@ -42,7 +75,7 @@ export const Default = () => {
         )}
         {secondaryNav && (
           <AppBar.SecondaryNav>
-            <AppBar.NavMenuItem label="Secondary" />
+            <AppBar.NavMenuItem label="Secondary">Hello!</AppBar.NavMenuItem>
           </AppBar.SecondaryNav>
         )}
         {primaryAction && (
@@ -59,7 +92,7 @@ export const Default = () => {
       <Box as="main" sx={{ p: 4, mt: position === 'fixed' ? 70 : 0 }}>
         <LoremIpsum paragraphs={12} />
       </Box>
-    </>
+    </ThemeProvider>
   )
 }
 


### PR DESCRIPTION
The AppBar uses a custom local theme with the font sizes from v2. However, this custom theme uses the default theme as the base instead of the parent theme provided by the surrounding page.