### PR TITLE
Quickfix: Add disabled button styles to the button in the design system

### DIFF
--- a/.changeset/happy-moles-play.md
+++ b/.changeset/happy-moles-play.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Add disabled button styles to the ds

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -21,6 +21,12 @@ const Base = styled('button')(
       outline: 'none',
       boxShadow: props.theme.shadows.focusRing,
     },
+    '&:disabled': {
+      // these are important to stop variants overriding them
+      backgroundColor: `${props.theme.colors.grey[200]} !important;`,
+      color: `${props.theme.colors.grey[500]} !important;`,
+      cursor: 'not-allowed',
+    },
   }),
   variant({
     prop: 'variant',
@@ -32,6 +38,10 @@ const Base = styled('button')(
         '&:hover': {
           bg: 'primary.700',
         },
+        // '&:disabled': {
+        //   bg: props.theme.colors.grey[200],
+        //   color: props.theme.colors.grey[500],
+        // },
       },
       secondary: {
         'color': 'primary.900',

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -38,10 +38,6 @@ const Base = styled('button')(
         '&:hover': {
           bg: 'primary.700',
         },
-        // '&:disabled': {
-        //   bg: props.theme.colors.grey[200],
-        //   color: props.theme.colors.grey[500],
-        // },
       },
       secondary: {
         'color': 'primary.900',

--- a/src/components/Button/index.stories.jsx
+++ b/src/components/Button/index.stories.jsx
@@ -32,6 +32,24 @@ Default.story = {
   name: 'default',
 }
 
+export const Disabled = () => {
+  const variant = select(
+    'Variant',
+    ['primary', 'secondary', 'danger'],
+    'primary'
+  )
+  return (
+    <Inline>
+      <Button disabled variant={variant} onClick={action('Button clicked')}>
+        Cant touch this
+      </Button>
+    </Inline>
+  )
+}
+Disabled.story = {
+  name: 'disabled',
+}
+
 function simulateNetworkRequest() {
   return new Promise(resolve => setTimeout(resolve, 3000))
 }


### PR DESCRIPTION
# What❓

Here I added styles for the button in the design system so it can be disabled and a story to go with it.

<img width="616" alt="Screenshot 2022-08-31 at 14 08 51" src="https://user-images.githubusercontent.com/1426390/187675104-8aaa4817-bd7c-46f2-9786-c4e467996587.png">


# Why 💁‍♀️

We need it in more and more places and having components to override this can be troublesome 
