### PR TITLE
Exclude node_modules from transitive dependencies in bundle.

### DIFF
--- a/.changeset/nasty-singers-chew.md
+++ b/.changeset/nasty-singers-chew.md
@@ -1,0 +1,5 @@
+---
+'@qualifyze/design-system': patch
+---
+
+Exclude node_modules from transitive dependencies in bundle.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
   },
   plugins: [
     resolve({ preferBuiltins: true, extensions: ['.js', '.jsx'] }),
-    babel({ babelHelpers: 'bundled' }),
+    babel({ babelHelpers: 'bundled', exclude: /node_modules/ }),
     commonjs(),
     styles(),
   ],


### PR DESCRIPTION
Since the last changes due to an unknown reason some of the transitive dependencies in the `node_modules` folder of dependencies were also transpiled with Babel and bundled. However, this is not necessary since they're going to be installed together with this package in the target environment.

Hence we exclude all `node_modules` folders from inclusion in the final bundle.