### PR TITLE
feat: upgrade pipeline to newest standards

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,0 @@
-{
-  "node": "16",
-  "sandboxes": ["qualifyze-design-system-basic-i7mrg2"]
-}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          # keep in sync with package.json#volta
           cache: npm
           node-version-file: package.json
 

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -13,24 +13,20 @@ on:
 jobs:
   test:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           # keep in sync with package.json#volta
-          node-version: 16.15.0
           cache: npm
-
-      - name: Install npm
-        # keep in sync with package.json#volta
-        run: npm install --global npm@8.5.5
+          node-version-file: package.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,24 +8,19 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          # keep in sync with package.json#volta
-          node-version: 16.15.0
           cache: npm
-
-      - name: Install npm
-        # keep in sync with package.json#volta
-        run: npm install --global npm@8.5.5
+          node-version-file: package.json
 
       - name: Install dependencies
         run: npm ci --legacy-peer-deps

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "stylelint-processor-styled-components": "^1.10.0"
   },
   "volta": {
-    "node": "16.15.0",
-    "npm": "8.5.5"
+    "node": "16.19.1"
   }
 }


### PR DESCRIPTION
1. Remove codesandbox folder, as it was throwing errors and it was not possible to pass --legacy-peer-deps to the install command which is required